### PR TITLE
Rescale key structures across expanded height

### DIFF
--- a/config/worldrise.toml
+++ b/config/worldrise.toml
@@ -1,3 +1,6 @@
 [worldrise]
 oreScaling = true
 carverEnabled = true
+strongholdScaling = true
+ancientCityScaling = true
+mineshaftScaling = true

--- a/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
+++ b/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
@@ -8,6 +8,9 @@ public class WorldriseConfig {
 
     public final ModConfigSpec.BooleanValue oreScaling;
     public final ModConfigSpec.BooleanValue carverEnabled;
+    public final ModConfigSpec.BooleanValue strongholdScaling;
+    public final ModConfigSpec.BooleanValue ancientCityScaling;
+    public final ModConfigSpec.BooleanValue mineshaftScaling;
 
     static {
         final var builder = new ModConfigSpec.Builder();
@@ -21,6 +24,12 @@ public class WorldriseConfig {
                             .define("oreScaling", true);
         carverEnabled = builder.comment("Enable custom ocean canyon carver")
                                .define("carverEnabled", true);
+        strongholdScaling = builder.comment("Enable height rescaling for strongholds")
+                                   .define("strongholdScaling", true);
+        ancientCityScaling = builder.comment("Enable height rescaling for ancient cities")
+                                     .define("ancientCityScaling", true);
+        mineshaftScaling = builder.comment("Enable height rescaling for mineshafts")
+                                  .define("mineshaftScaling", true);
         builder.pop();
     }
 }

--- a/src/main/java/com/yourorg/worldrise/data/StructureSetLoader.java
+++ b/src/main/java/com/yourorg/worldrise/data/StructureSetLoader.java
@@ -1,0 +1,94 @@
+package com.yourorg.worldrise.data;
+
+import com.yourorg.worldrise.config.WorldriseConfig;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Utility responsible for determining which structure set overrides should be applied. The
+ * selection is controlled through configuration toggles so users can opt out of conflicting
+ * datapack adjustments.
+ */
+public final class StructureSetLoader {
+
+    private static final Path STRUCTURE_SET_ROOT =
+            Path.of("data", "worldrise", "worldgen", "structure_set");
+
+    private StructureSetLoader() { }
+
+    /**
+     * Resolves the structure set override files that should be loaded for the current
+     * configuration.
+     *
+     * @param resourceRoot root folder that contains the mod data pack resources
+     * @return immutable list of absolute paths to structure set overrides that should be applied
+     */
+    public static List<Path> enabledStructureSets(Path resourceRoot) {
+        return enabledStructureSets(resourceRoot,
+                StructureSetToggles.fromConfig(WorldriseConfig.INSTANCE));
+    }
+
+    static List<Path> enabledStructureSets(Path resourceRoot, StructureSetToggles toggles) {
+        Path base = resourceRoot.resolve(STRUCTURE_SET_ROOT);
+        List<Path> enabled = new ArrayList<>();
+        addIfEnabled(enabled, base.resolve("stronghold.json"), toggles.strongholdScaling());
+        addIfEnabled(enabled, base.resolve("ancient_city.json"), toggles.ancientCityScaling());
+        addIfEnabled(enabled, base.resolve("mineshaft.json"), toggles.mineshaftScaling());
+        return List.copyOf(enabled);
+    }
+
+    private static void addIfEnabled(List<Path> enabled, Path candidate, boolean isEnabled) {
+        if (isEnabled && Files.exists(candidate)) {
+            enabled.add(candidate);
+        }
+    }
+
+    public interface StructureSetToggles {
+        boolean strongholdScaling();
+
+        boolean ancientCityScaling();
+
+        boolean mineshaftScaling();
+
+        static StructureSetToggles fromConfig(WorldriseConfig config) {
+            return new StructureSetToggles() {
+                @Override
+                public boolean strongholdScaling() {
+                    return config.strongholdScaling.get();
+                }
+
+                @Override
+                public boolean ancientCityScaling() {
+                    return config.ancientCityScaling.get();
+                }
+
+                @Override
+                public boolean mineshaftScaling() {
+                    return config.mineshaftScaling.get();
+                }
+            };
+        }
+
+        static StructureSetToggles of(boolean stronghold, boolean ancientCity, boolean mineshaft) {
+            return new StructureSetToggles() {
+                @Override
+                public boolean strongholdScaling() {
+                    return stronghold;
+                }
+
+                @Override
+                public boolean ancientCityScaling() {
+                    return ancientCity;
+                }
+
+                @Override
+                public boolean mineshaftScaling() {
+                    return mineshaft;
+                }
+            };
+        }
+    }
+}
+

--- a/src/main/resources/data/worldrise/worldgen/structure_set/ancient_city.json
+++ b/src/main/resources/data/worldrise/worldgen/structure_set/ancient_city.json
@@ -1,0 +1,17 @@
+{
+  "structures": [
+    { "structure": "minecraft:ancient_city", "weight": 1 }
+  ],
+  "placement": {
+    "type": "minecraft:random_spread",
+    "salt": 20083232,
+    "spacing": 40,
+    "separation": 8
+  },
+  "project_to_heightmap": null,
+  "height_range": {
+    "type": "minecraft:uniform",
+    "min_inclusive": { "absolute": -200 },
+    "max_inclusive": { "absolute": -120 }
+  }
+}

--- a/src/main/resources/data/worldrise/worldgen/structure_set/mineshaft.json
+++ b/src/main/resources/data/worldrise/worldgen/structure_set/mineshaft.json
@@ -1,0 +1,17 @@
+{
+  "structures": [
+    { "structure": "minecraft:mineshaft", "weight": 1 }
+  ],
+  "placement": {
+    "type": "minecraft:random_spread",
+    "salt": 10387313,
+    "spacing": 20,
+    "separation": 4
+  },
+  "project_to_heightmap": null,
+  "height_range": {
+    "type": "minecraft:uniform",
+    "min_inclusive": { "absolute": -200 },
+    "max_inclusive": { "absolute": 60 }
+  }
+}

--- a/src/main/resources/data/worldrise/worldgen/structure_set/stronghold.json
+++ b/src/main/resources/data/worldrise/worldgen/structure_set/stronghold.json
@@ -1,0 +1,19 @@
+{
+  "structures": [
+    { "structure": "minecraft:stronghold", "weight": 1 }
+  ],
+  "placement": {
+    "type": "minecraft:concentric_rings",
+    "distance": 32,
+    "spread": 3,
+    "count": 128,
+    "preferred_biomes": "#minecraft:has_stronghold",
+    "salt": 0
+  },
+  "project_to_heightmap": null,
+  "height_range": {
+    "type": "minecraft:uniform",
+    "min_inclusive": { "absolute": -128 },
+    "max_inclusive": { "absolute": 128 }
+  }
+}

--- a/src/test/java/com/yourorg/worldrise/data/StructureSetLoaderTest.java
+++ b/src/test/java/com/yourorg/worldrise/data/StructureSetLoaderTest.java
@@ -1,0 +1,40 @@
+package com.yourorg.worldrise.data;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.yourorg.worldrise.data.StructureSetLoader.StructureSetToggles;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StructureSetLoaderTest {
+
+    private static final Path RESOURCE_ROOT = Path.of("src", "main", "resources");
+
+    @Test
+    @DisplayName("All structure set overrides are enabled by default")
+    void allStructureSetsEnabledByDefault() {
+        List<Path> enabled = StructureSetLoader.enabledStructureSets(RESOURCE_ROOT,
+                StructureSetToggles.of(true, true, true));
+
+        assertEquals(3, enabled.size(), "Expected three structure set overrides to load");
+        assertTrue(enabled.stream().anyMatch(path -> path.endsWith("stronghold.json")),
+                "Stronghold override should be included");
+        assertTrue(enabled.stream().anyMatch(path -> path.endsWith("ancient_city.json")),
+                "Ancient city override should be included");
+        assertTrue(enabled.stream().anyMatch(path -> path.endsWith("mineshaft.json")),
+                "Mineshaft override should be included");
+    }
+
+    @Test
+    @DisplayName("Disabled toggles skip the corresponding structure set overrides")
+    void disabledTogglesSkipOverrides() {
+        List<Path> enabled = StructureSetLoader.enabledStructureSets(RESOURCE_ROOT,
+                StructureSetToggles.of(false, true, false));
+
+        assertEquals(1, enabled.size(), "Only ancient city override should remain active");
+        assertTrue(enabled.get(0).endsWith("ancient_city.json"),
+                "Ancient city override should be the only active entry");
+    }
+}


### PR DESCRIPTION
## Summary
- add structure set overrides to reposition strongholds, ancient cities, and mineshafts within the expanded world height
- gate the overrides behind new configuration toggles and expose a loader utility for determining active overrides
- cover the loader logic with unit tests to ensure toggles disable the correct structure sets

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dc0c22c4a88327b008eb643b9d0007