### PR TITLE
Enforce Java 21 mixin compatibility level

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven {
+        name = 'Sponge'
+        url = 'https://repo.spongepowered.org/repository/maven-public/'
+    }
 }
 
 java {
@@ -12,8 +16,14 @@ java {
     }
 }
 
+configurations.all {
+    exclude group: "com.llamalad7", module: "MixinExtras"
+    exclude group: "com.github.LlamaLad7", module: "MixinExtras"
+}
+
 dependencies {
     implementation 'com.google.code.gson:gson:2.11.0'
+    compileOnly 'org.spongepowered:mixin:0.8.7'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
     testImplementation 'org.tomlj:tomlj:1.1.0'
@@ -34,7 +44,7 @@ tasks.register('rescaleOres', JavaExec) {
     ]
 }
 
-tasks.register("validateNoMixinExtrasImports") {
+tasks.register("validateNoExternalMixinExtras") {
     doLast {
         fileTree("versions").matching {
             include "**/*.java"
@@ -47,5 +57,5 @@ tasks.register("validateNoMixinExtrasImports") {
 }
 
 tasks.named("build").configure {
-    dependsOn("validateNoMixinExtrasImports")
+    dependsOn("validateNoExternalMixinExtras")
 }

--- a/src/main/java/com/cyberday1/theexpanse/MixinCompatBootstrap.java
+++ b/src/main/java/com/cyberday1/theexpanse/MixinCompatBootstrap.java
@@ -1,0 +1,10 @@
+package com.cyberday1.theexpanse;
+
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+public class MixinCompatBootstrap {
+    public static void enforce() {
+        MixinEnvironment.getDefaultEnvironment()
+            .setCompatibilityLevel(MixinEnvironment.CompatibilityLevel.JAVA_21);
+    }
+}

--- a/src/main/java/com/yourorg/worldrise/Worldrise.java
+++ b/src/main/java/com/yourorg/worldrise/Worldrise.java
@@ -1,8 +1,11 @@
 package com.yourorg.worldrise;
 
+import com.cyberday1.theexpanse.MixinCompatBootstrap;
 import net.neoforged.fml.common.Mod;
 
 @Mod("worldrise")
 public final class Worldrise {
-    public Worldrise() { /* Data-driven mod */ }
+    public Worldrise() {
+        MixinCompatBootstrap.enforce();
+    }
 }


### PR DESCRIPTION
## Summary
- exclude external MixinExtras artifacts in Gradle and add the Sponge repository for mixin compile-time resolution
- add a Java 21 mixin compatibility bootstrapper and call it during mod initialization

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68dc0d6024748327a5eb6307814139ac