### PR TITLE
Add validation around vendored build artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import java.nio.file.Paths
 
 plugins {
     id 'java'
@@ -78,6 +79,48 @@ tasks.register("validateNoExternalMixinExtras") {
     }
 }
 
+tasks.register("validateVendoredProjectsStripped") {
+    group = "verification"
+    description = "Ensure vendored mods do not include their own build scripts or mods.toml descriptors"
+
+    doLast {
+        def vendorRoot = file("src/main/java/com/yourorg/worldrise/vendor")
+        if (vendorRoot.exists()) {
+            def forbiddenNames = ["build.gradle", "settings.gradle", "gradlew", "gradlew.bat"]
+            vendorRoot.eachFileRecurse { file ->
+                if (file.isFile()) {
+                    if (forbiddenNames.contains(file.name)) {
+                        def relative = vendorRoot.toPath().relativize(file.toPath())
+                        throw new GradleException("Vendored project build file ${relative} should be removed")
+                    }
+
+                    if (file.name == "mods.toml" && file.parentFile?.name == "META-INF") {
+                        def relative = vendorRoot.toPath().relativize(file.toPath())
+                        throw new GradleException("Vendored project metadata ${relative} should be removed")
+                    }
+                }
+            }
+        }
+
+        def resourceRoot = file("src/main/resources").canonicalFile
+        def modsTomls = fileTree(resourceRoot) {
+            include "**/mods.toml"
+        }.collect { it.canonicalFile }
+
+        def expected = resourceRoot.toPath().resolve(Paths.get("META-INF", "mods.toml")).toFile().canonicalFile
+        if (!modsTomls.contains(expected)) {
+            def relativePath = resourceRoot.toPath().relativize(expected.toPath())
+            throw new GradleException("Worldrise mods.toml is missing from ${relativePath}")
+        }
+
+        def extras = modsTomls.findAll { it != expected }
+        if (!extras.isEmpty()) {
+            def relativeExtras = extras.collect { resourceRoot.toPath().relativize(it.toPath()) }
+            throw new GradleException("Unexpected mods.toml files found: ${relativeExtras}")
+        }
+    }
+}
+
 tasks.named("build").configure {
-    dependsOn("validateMixinCompatLevel", "validateNoExternalMixinExtras")
+    dependsOn("validateMixinCompatLevel", "validateNoExternalMixinExtras", "validateVendoredProjectsStripped")
 }

--- a/src/test/java/com/worldrise/WorldriseResourceValidationTest.java
+++ b/src/test/java/com/worldrise/WorldriseResourceValidationTest.java
@@ -192,4 +192,52 @@ class WorldriseResourceValidationTest {
             assertTrue(present, () -> biome + " should be included in ocean_like tag");
         }
     }
+
+    @Test
+    @DisplayName("Vendored projects omit build tooling and duplicate mods metadata")
+    void vendoredProjectsStripped() throws IOException {
+        Path vendorRoot = Path.of("src", "main", "java", "com", "yourorg", "worldrise", "vendor")
+                .toAbsolutePath().normalize();
+        if (Files.exists(vendorRoot)) {
+            try (Stream<Path> paths = Files.walk(vendorRoot)) {
+                List<Path> forbidden = paths
+                        .filter(Files::isRegularFile)
+                        .filter(path -> {
+                            String name = path.getFileName().toString();
+                            if (name.equals("build.gradle") || name.equals("settings.gradle")
+                                    || name.equals("gradlew") || name.equals("gradlew.bat")) {
+                                return true;
+                            }
+
+                            if (name.equals("mods.toml")) {
+                                Path parent = path.getParent();
+                                return parent != null
+                                        && parent.getFileName() != null
+                                        && parent.getFileName().toString().equals("META-INF");
+                            }
+
+                            return false;
+                        })
+                        .map(path -> vendorRoot.relativize(path.toAbsolutePath().normalize()))
+                        .collect(Collectors.toList());
+                assertTrue(forbidden.isEmpty(),
+                        () -> "Vendored projects should not ship Gradle build files or META-INF/mods.toml descriptors: "
+                                + forbidden);
+            }
+        }
+
+        Path resourceRoot = Path.of("src", "main", "resources").toAbsolutePath().normalize();
+        List<Path> mods;
+        try (Stream<Path> modStream = Files.walk(resourceRoot)
+                .filter(Files::isRegularFile)
+                .filter(path -> path.getFileName().toString().equals("mods.toml"))) {
+            mods = modStream
+                    .map(resourceRoot::relativize)
+                    .collect(Collectors.toList());
+        }
+
+        Path expectedMods = Path.of("META-INF", "mods.toml");
+        assertEquals(List.of(expectedMods), mods,
+                () -> "Only the Worldrise mods.toml should remain under resources. Found: " + mods);
+    }
 }


### PR DESCRIPTION
## Summary
- add a Gradle verification task that fails the build if vendored sources contain Gradle tooling or extra META-INF/mods.toml files
- extend the resource validation tests to assert only the Worldrise mods descriptor remains and vendored trees are stripped

## Testing
- `./gradlew test` *(fails: project depends on modding APIs that are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc400a10288327832149fbdae923a9