### PR TITLE
Add toggles for vendored worldgen initialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ configurations.all {
 dependencies {
     implementation 'com.google.code.gson:gson:2.11.0'
     compileOnly 'org.spongepowered:mixin:0.8.5'
+    compileOnly 'net.neoforged:neoforge:21.1.209'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
     testImplementation 'org.tomlj:tomlj:1.1.0'

--- a/config/worldrise.toml
+++ b/config/worldrise.toml
@@ -15,3 +15,5 @@ netherScaling = true
 endScaling = true
 oreDensityMultiplier = 1.0
 carverChanceMultiplier = 1.0
+tectonicEnabled = true
+lithoEnabled = true

--- a/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
+++ b/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
@@ -22,6 +22,8 @@ public class WorldriseConfig {
     public final ModConfigSpec.BooleanValue endCityScaling;
     public final ModConfigSpec.BooleanValue netherScaling;
     public final ModConfigSpec.BooleanValue endScaling;
+    public final ModConfigSpec.BooleanValue tectonicEnabled;
+    public final ModConfigSpec.BooleanValue lithoEnabled;
 
     static {
         final var builder = new ModConfigSpec.Builder();
@@ -63,6 +65,10 @@ public class WorldriseConfig {
                                .define("netherScaling", true);
         endScaling = builder.comment("Enable expanded end vertical range")
                             .define("endScaling", true);
+        tectonicEnabled = builder.comment("Enable vendored tectonic configuration loader")
+                                 .define("tectonicEnabled", true);
+        lithoEnabled = builder.comment("Enable vendored lithostitched registry hooks")
+                               .define("lithoEnabled", true);
         builder.pop();
     }
 }

--- a/src/main/java/com/yourorg/worldrise/vendor/VendoredWorldgen.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/VendoredWorldgen.java
@@ -1,5 +1,6 @@
 package com.yourorg.worldrise.vendor;
 
+import com.yourorg.worldrise.config.WorldriseConfig;
 import com.yourorg.worldrise.vendor.litho.config.ConfigHandler;
 import com.yourorg.worldrise.vendor.litho.registry.LithostitchedBuiltInRegistries;
 import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
@@ -10,7 +11,20 @@ public final class VendoredWorldgen {
     }
 
     public static void init() {
-        ConfigHandler.load(FMLPaths.CONFIGDIR.get().resolve("lithostitched.json"));
-        LithostitchedBuiltInRegistries.init(FMLJavaModLoadingContext.get().getModEventBus());
+        boolean tectonicEnabled = WorldriseConfig.INSTANCE.tectonicEnabled.get();
+        boolean lithoEnabled = WorldriseConfig.INSTANCE.lithoEnabled.get();
+
+        if (!tectonicEnabled && !lithoEnabled) {
+            return;
+        }
+
+        if (lithoEnabled) {
+            ConfigHandler.load(FMLPaths.CONFIGDIR.get().resolve("lithostitched.json"));
+            LithostitchedBuiltInRegistries.init(FMLJavaModLoadingContext.get().getModEventBus());
+        }
+
+        if (tectonicEnabled) {
+            // Reserved for future tectonic initialization.
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `tectonicEnabled` and `lithoEnabled` toggles to the Worldrise config API and default TOML
- gate the vendored world generation bootstrap behind the new toggles
- declare NeoForge as a compileOnly dependency so the vendored sources compile

## Testing
- `./gradlew build test` *(fails: compileJava cannot resolve NeoForge/Minecraft types in vendored sources)*

------
https://chatgpt.com/codex/tasks/task_e_68dc483cd368832781b07b0a22bf0306