### PR TITLE
Stub Litho surface and density managers on NeoForge

### DIFF
--- a/src/main/java/com/yourorg/worldrise/vendor/VendoredWorldgen.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/VendoredWorldgen.java
@@ -3,6 +3,7 @@ package com.yourorg.worldrise.vendor;
 import com.yourorg.worldrise.config.WorldriseConfig;
 import com.yourorg.worldrise.vendor.litho.config.ConfigHandler;
 import com.yourorg.worldrise.vendor.litho.registry.LithostitchedBuiltInRegistries;
+import com.yourorg.worldrise.vendor.litho.worldgen.surface.SurfaceRuleManager;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.loading.FMLPaths;
@@ -23,6 +24,7 @@ public final class VendoredWorldgen {
         if (lithoEnabled) {
             ConfigHandler.load(FMLPaths.CONFIGDIR.get().resolve("lithostitched.json"));
             LithostitchedBuiltInRegistries.init(bus);
+            SurfaceRuleManager.init();
         }
 
         if (tectonicEnabled) {

--- a/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/client/IntegratedServerMixin.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/client/IntegratedServerMixin.java
@@ -1,7 +1,6 @@
 package com.yourorg.worldrise.vendor.litho.mixin.client;
 
 import com.yourorg.worldrise.vendor.litho.worldgen.modifier.Modifier;
-import com.yourorg.worldrise.vendor.litho.worldgen.surface.SurfaceRuleManager;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,9 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(IntegratedServer.class)
 public final class IntegratedServerMixin {
-	@Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/server/IntegratedServer;loadLevel()V", shift = At.Shift.BEFORE))
-	private void initServer(CallbackInfoReturnable<Boolean> info) {
-		Modifier.applyModifiers((MinecraftServer) (Object) this);
-		SurfaceRuleManager.applySurfaceRules((MinecraftServer) (Object) this);
-	}
+        @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/server/IntegratedServer;loadLevel()V", shift = At.Shift.BEFORE), allow = 1)
+        private void applyModdedBiomeSlices(CallbackInfoReturnable<Boolean> info) {
+                Modifier.applyModifiers((MinecraftServer) (Object) this);
+        }
 }

--- a/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/common/GameTestServerMixin.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/common/GameTestServerMixin.java
@@ -1,7 +1,6 @@
 package com.yourorg.worldrise.vendor.litho.mixin.common;
 
 import com.yourorg.worldrise.vendor.litho.worldgen.modifier.Modifier;
-import com.yourorg.worldrise.vendor.litho.worldgen.surface.SurfaceRuleManager;
 import net.minecraft.gametest.framework.GameTestServer;
 import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -10,10 +9,9 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(GameTestServer.class)
-public abstract class GameTestServerMixin {
-	@Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/gametest/framework/GameTestServer;loadLevel()V", shift = At.Shift.BEFORE))
-	private void initServer(CallbackInfoReturnable<Boolean> info) {
-		Modifier.applyModifiers((MinecraftServer) (Object) this);
-		SurfaceRuleManager.applySurfaceRules((MinecraftServer) (Object) this);
-	}
+public final class GameTestServerMixin {
+        @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/gametest/framework/GameTestServer;loadLevel()V", shift = At.Shift.BEFORE), allow = 1)
+        private void applyModdedBiomeSlices(CallbackInfoReturnable<Boolean> info) {
+                Modifier.applyModifiers((MinecraftServer) (Object) this);
+        }
 }

--- a/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/server/DedicatedServerMixin.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/litho/mixin/server/DedicatedServerMixin.java
@@ -1,7 +1,6 @@
 package com.yourorg.worldrise.vendor.litho.mixin.server;
 
 import com.yourorg.worldrise.vendor.litho.worldgen.modifier.Modifier;
-import com.yourorg.worldrise.vendor.litho.worldgen.surface.SurfaceRuleManager;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.dedicated.DedicatedServer;
 import org.spongepowered.asm.mixin.Mixin;
@@ -11,9 +10,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(DedicatedServer.class)
 public final class DedicatedServerMixin {
-	@Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadLevel()V", shift = At.Shift.BEFORE), allow = 1)
-	private void applyModdedBiomeSlices(CallbackInfoReturnable<Boolean> info) {
-		Modifier.applyModifiers((MinecraftServer) (Object) this);
-		SurfaceRuleManager.applySurfaceRules((MinecraftServer) (Object) this);
-	}
+        @Inject(method = "initServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/dedicated/DedicatedServer;loadLevel()V", shift = At.Shift.BEFORE), allow = 1)
+        private void applyModdedBiomeSlices(CallbackInfoReturnable<Boolean> info) {
+                Modifier.applyModifiers((MinecraftServer) (Object) this);
+        }
 }

--- a/src/main/java/com/yourorg/worldrise/vendor/litho/worldgen/placementcondition/SampleDensityPlacementCondition.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/litho/worldgen/placementcondition/SampleDensityPlacementCondition.java
@@ -2,97 +2,36 @@ package com.yourorg.worldrise.vendor.litho.worldgen.placementcondition;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
-import com.mojang.serialization.codecs.RecordCodecBuilder;
-import com.yourorg.worldrise.vendor.litho.mixin.common.RandomStateAccessor;
+import com.yourorg.worldrise.vendor.litho.LithostitchedCommon;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Holder;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.levelgen.*;
-import net.minecraft.world.level.levelgen.structure.Structure;
-import net.minecraft.world.level.levelgen.synth.BlendedNoise;
-import net.minecraft.world.level.levelgen.synth.NormalNoise;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+/**
+ * Stub replacement for SampleDensityPlacementCondition.
+ * Disabled under NeoForge: always returns false.
+ */
+public final class SampleDensityPlacementCondition implements PlacementCondition {
+    private static final SampleDensityPlacementCondition INSTANCE = new SampleDensityPlacementCondition();
 
-public record SampleDensityPlacementCondition(Holder<DensityFunction> densityFunction, Optional<Double> minInclusive, Optional<Double> maxInclusive) implements PlacementCondition {
-    public static final MapCodec<SampleDensityPlacementCondition> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
-        DensityFunction.CODEC.fieldOf("density_function").forGetter(SampleDensityPlacementCondition::densityFunction),
-        Codec.DOUBLE.optionalFieldOf("min_inclusive").forGetter(SampleDensityPlacementCondition::minInclusive),
-        Codec.DOUBLE.optionalFieldOf("max_inclusive").forGetter(SampleDensityPlacementCondition::maxInclusive)
-    ).apply(instance, SampleDensityPlacementCondition::new));
+    public static final MapCodec<SampleDensityPlacementCondition> CODEC = MapCodec.unit(() -> INSTANCE);
+
+    public static final Codec<SampleDensityPlacementCondition> DIRECT_CODEC = CODEC.codec();
+
+    private static boolean warned;
+
+    private SampleDensityPlacementCondition() {
+    }
 
     @Override
     public boolean test(Context context, BlockPos pos) {
-        if (!(context.generator() instanceof NoiseBasedChunkGenerator chunkGenerator)) return false;
-
-        DensityFunction df = this.densityFunction.value().mapAll(new NoiseWiringHelper(context.seed(), chunkGenerator.settings.value().useLegacyRandomSource(), context.randomState(), ((RandomStateAccessor)(Object)context.randomState()).getRandom()));
-        double density = df.compute(new DensityFunction.SinglePointContext(pos.getX(), pos.getY(), pos.getZ()));
-
-        boolean min = this.minInclusive.isEmpty() || density >= this.minInclusive.get();
-        boolean max = this.maxInclusive.isEmpty() || density <= this.maxInclusive.get();
-        return min && max;
+        if (!warned) {
+            LithostitchedCommon.LOGGER.warn("SampleDensityPlacementCondition is disabled under NeoForge and will always return false.");
+            warned = true;
+        }
+        return false;
     }
 
     @Override
     public MapCodec<? extends PlacementCondition> codec() {
         return CODEC;
-    }
-
-    private static class NoiseWiringHelper implements DensityFunction.Visitor {
-        private final Map<DensityFunction, DensityFunction> wrapped = new HashMap<>();
-        private final boolean useLegacySource;
-        private final long seed;
-        final RandomState randomState;
-        final PositionalRandomFactory random;
-        private RandomSource newLegacyInstance(long noiseSeed) {
-            return new LegacyRandomSource(this.seed + noiseSeed);
-        }
-
-        NoiseWiringHelper(long seed, boolean useLegacySource, RandomState randomState, PositionalRandomFactory random) {
-            this.seed = seed;
-            this.useLegacySource = useLegacySource;
-            this.randomState = randomState;
-            this.random = random;
-        }
-
-        public DensityFunction.NoiseHolder visitNoise(DensityFunction.NoiseHolder noiseHolder) {
-            Holder<NormalNoise.NoiseParameters> noiseData = noiseHolder.noiseData();
-            NormalNoise noise;
-            if (this.useLegacySource) {
-                if (noiseData.is(Noises.TEMPERATURE)) {
-                    noise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(0L), new NormalNoise.NoiseParameters(-7, 1.0, new double[]{1.0}));
-                    return new DensityFunction.NoiseHolder(noiseData, noise);
-                }
-
-                if (noiseData.is(Noises.VEGETATION)) {
-                    noise = NormalNoise.createLegacyNetherBiome(this.newLegacyInstance(1L), new NormalNoise.NoiseParameters(-7, 1.0, new double[]{1.0}));
-                    return new DensityFunction.NoiseHolder(noiseData, noise);
-                }
-
-                if (noiseData.is(Noises.SHIFT)) {
-                    noise = NormalNoise.create(this.random.fromHashOf(Noises.SHIFT.location()), new NormalNoise.NoiseParameters(0, 0.0, new double[0]));
-                    return new DensityFunction.NoiseHolder(noiseData, noise);
-                }
-            }
-
-            noise = this.randomState.getOrCreateNoise(noiseData.unwrapKey().orElseThrow());
-            return new DensityFunction.NoiseHolder(noiseData, noise);
-        }
-
-        private DensityFunction wrapNew(DensityFunction densityFunction) {
-            if (densityFunction instanceof BlendedNoise $$1) {
-                RandomSource $$2x = this.useLegacySource ? this.newLegacyInstance(0L) : this.random.fromHashOf(ResourceLocation.withDefaultNamespace("terrain"));
-                return $$1.withNewRandom($$2x);
-            } else {
-                return (densityFunction instanceof DensityFunctions.EndIslandDensityFunction ? new DensityFunctions.EndIslandDensityFunction(this.seed) : densityFunction);
-            }
-        }
-
-        public DensityFunction apply(DensityFunction densityFunction) {
-            return this.wrapped.computeIfAbsent(densityFunction, this::wrapNew);
-        }
     }
 }

--- a/src/main/java/com/yourorg/worldrise/vendor/litho/worldgen/surface/SurfaceRuleManager.java
+++ b/src/main/java/com/yourorg/worldrise/vendor/litho/worldgen/surface/SurfaceRuleManager.java
@@ -1,91 +1,21 @@
 package com.yourorg.worldrise.vendor.litho.worldgen.surface;
 
-import com.mojang.datafixers.util.Pair;
 import com.yourorg.worldrise.vendor.litho.LithostitchedCommon;
-import com.yourorg.worldrise.vendor.litho.registry.LithostitchedRegistryKeys;
-import com.yourorg.worldrise.vendor.litho.worldgen.modifier.AddSurfaceRuleModifier;
-import net.minecraft.core.Holder;
-import net.minecraft.core.Registry;
-import net.minecraft.core.RegistryAccess;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.server.MinecraftServer;
-import net.minecraft.world.level.chunk.ChunkGenerator;
-import net.minecraft.world.level.dimension.LevelStem;
-import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
-import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
-import net.minecraft.world.level.levelgen.SurfaceRules;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
- * The manager class for surface rule injection.
- *
- * @author Apollo
-*/
-public class SurfaceRuleManager {
+ * Stub replacement for SurfaceRuleManager.
+ * Disabled under NeoForge: no-op.
+ */
+public final class SurfaceRuleManager {
+    private static boolean warned;
 
-    @SuppressWarnings("deprecation")
-    public static void applySurfaceRules(MinecraftServer server) {
-        RegistryAccess registryAccess = server.registryAccess();
-        var surfaceRules = registryAccess.registryOrThrow(LithostitchedRegistryKeys.WORLDGEN_MODIFIER).entrySet().stream().filter((entry) -> entry.getValue() instanceof AddSurfaceRuleModifier).collect(Collectors.toSet());
-        if (surfaceRules.isEmpty()) return;
-
-        HashMap<ResourceLocation, ArrayList<Pair<ResourceLocation, AddSurfaceRuleModifier>>> assignedSurfaceRules = new HashMap<>();
-        for (var assignedSurfaceRule : surfaceRules) {
-            AddSurfaceRuleModifier slice = (AddSurfaceRuleModifier)assignedSurfaceRule.getValue();
-            slice.levels().forEach(levelStemResourceKey -> assignedSurfaceRules.computeIfAbsent(levelStemResourceKey.location(), __ -> new ArrayList<>()).add(Pair.of(assignedSurfaceRule.getKey().location(), slice)));
-        }
-
-        Registry<LevelStem> dimensions = registryAccess.registryOrThrow(Registries.LEVEL_STEM);
-        for (Map.Entry<ResourceKey<LevelStem>, LevelStem> entry : dimensions.entrySet()) {
-            ResourceLocation location = entry.getKey().location();
-            var surfaceRulesForKey = assignedSurfaceRules.get(location);
-            if (surfaceRulesForKey != null) {
-                //if (surfaceRulesForKey.isEmpty()) {
-                //    LithostitchedCommon.LOGGER.info("Skipped applying surface rule additions for '" + location + "' dimension as none exist");
-                //    continue;
-                //}
-                ChunkGenerator chunkGenerator = entry.getValue().generator();
-                if (!(chunkGenerator instanceof NoiseBasedChunkGenerator)) continue;
-                NoiseGeneratorSettings settings = ((NoiseBasedChunkGenerator) chunkGenerator).generatorSettings().value();
-                SurfaceRules.RuleSource oldRules = settings.surfaceRule();
-                // Noise generator settings must be rebuilt due to Forge not allowing surface rules to be directly modified.
-                ((NoiseBasedChunkGenerator)chunkGenerator).settings = Holder.direct(new NoiseGeneratorSettings(
-                    settings.noiseSettings(),
-                    settings.defaultBlock(),
-                    settings.defaultFluid(),
-                    settings.noiseRouter(),
-                    buildModdedSurfaceRules(surfaceRulesForKey, oldRules),
-                    settings.spawnTarget(),
-                    settings.seaLevel(),
-                    settings.disableMobGeneration(),
-                    settings.isAquifersEnabled(),
-                    settings.oreVeinsEnabled(),
-                    settings.useLegacyRandomSource()
-                ));
-
-                LithostitchedCommon.debug("Applied {} surface rule additions for '{}' dimension", surfaceRulesForKey.size(), location);
-            }
-        }
+    private SurfaceRuleManager() {
     }
 
-    private static SurfaceRules.RuleSource buildModdedSurfaceRules(ArrayList<Pair<ResourceLocation, AddSurfaceRuleModifier>> moddedSourceList, SurfaceRules.RuleSource originalSource) {
-        // TODO: Implement caching
-        List<SurfaceRules.RuleSource> newRuleSourceList = new ArrayList<>();
-        moddedSourceList.forEach((pair) -> newRuleSourceList.add(pair.getSecond().surfaceRule()));
-
-        newRuleSourceList.add(originalSource);
-        if (originalSource instanceof LithostitchedSurfaceRules.TransientMergedRuleSource) {
-            ((LithostitchedSurfaceRules.TransientMergedRuleSource) originalSource).sequence().addAll(newRuleSourceList);
-            return originalSource;
-        } else {
-            return new LithostitchedSurfaceRules.TransientMergedRuleSource(newRuleSourceList, originalSource);
+    public static void init() {
+        if (!warned) {
+            LithostitchedCommon.LOGGER.warn("SurfaceRuleManager is disabled under NeoForge; surface rule modifications will not be applied.");
+            warned = true;
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the Litho sample-density placement condition with a stub that always fails under NeoForge
- replace the Litho surface rule manager with a no-op stub and drop mixin calls to the removed API
- initialize the stub manager during Litho startup to emit a warning about disabled surface rules

## Testing
- ./gradlew build *(fails: existing WorldriseConfig references ModConfigSpec.ConfigValue#defineList which is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc9f27a66c83278adde7a0d9d7f815