### PR TITLE
Refactor config multipliers to comma-separated strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ performance with resource availability when stretching the world height:
   placement attempt.
 * `scaling.defaultCarverMultiplier` – Global multiplier applied to carver `probability`
   fields when no override matches. Probabilities are clamped to the `[0.0, 1.0]` range.
-* `scaling.biomeOreMultipliers` / `scaling.biomeCarverMultipliers` – Lists of strings in the
-  format `<biome-id or #tag>=<multiplier>`. These entries override the default multipliers for
+* `scaling.biomeOreMultipliers` / `scaling.biomeCarverMultipliers` – Comma-separated strings in
+  the format `<biome-id or #tag>=<multiplier>`. These entries override the default multipliers for
   matching biomes or biome tags, enabling biome-specific ore density or carver frequency.
 
 Lower multipliers lighten chunk generation cost by creating fewer features, whereas higher

--- a/config/worldrise.toml
+++ b/config/worldrise.toml
@@ -20,9 +20,9 @@ lithoEnabled = true
 defaultOreMultiplier = 1.0
 defaultCarverMultiplier = 1.0
 
-# Per-biome overrides: biome tag or ID = multiplier
-biomeOreMultipliers = ["#minecraft:is_mountain=1.5", "#minecraft:is_ocean=0.5"]
-biomeCarverMultipliers = ["#worldrise:ocean_biomes=2.0"]
+# Per-biome overrides: comma-separated list of biome tag or ID = multiplier entries
+biomeOreMultipliers = "#minecraft:is_mountain=1.5,#minecraft:is_ocean=0.5"
+biomeCarverMultipliers = "#worldrise:ocean_biomes=2.0"
 
 [worldrise.compatibility]
 biomesoplenty = true

--- a/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
+++ b/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
@@ -14,8 +14,8 @@ public class WorldriseConfig {
     public final ModConfigSpec.BooleanValue blueHoles;
     public final ModConfigSpec.DoubleValue defaultOreMultiplier;
     public final ModConfigSpec.DoubleValue defaultCarverMultiplier;
-    public final ModConfigSpec.ConfigValue<List<? extends String>> biomeOreMultipliers;
-    public final ModConfigSpec.ConfigValue<List<? extends String>> biomeCarverMultipliers;
+    public final ModConfigSpec.ConfigValue<String> biomeOreMultipliersRaw;
+    public final ModConfigSpec.ConfigValue<String> biomeCarverMultipliersRaw;
     public final ModConfigSpec.BooleanValue strongholdScaling;
     public final ModConfigSpec.BooleanValue ancientCityScaling;
     public final ModConfigSpec.BooleanValue mineshaftScaling;
@@ -53,10 +53,10 @@ public class WorldriseConfig {
                                        .defineInRange("defaultOreMultiplier", 1.0, 0.0, 10.0);
         defaultCarverMultiplier = builder.comment("Default carver probability multiplier (applied when no biome override matches)")
                                           .defineInRange("defaultCarverMultiplier", 1.0, 0.0, 10.0);
-        biomeOreMultipliers = builder.comment("Biome-specific ore multipliers")
-                                     .defineList("biomeOreMultipliers", List.of(), o -> o instanceof String);
-        biomeCarverMultipliers = builder.comment("Biome-specific carver multipliers")
-                                        .defineList("biomeCarverMultipliers", List.of(), o -> o instanceof String);
+        builder.comment("Biome-specific ore multipliers (comma-separated list of biome_id=multiplier)");
+        biomeOreMultipliersRaw = builder.define("biomeOreMultipliers", "");
+        builder.comment("Biome-specific carver multipliers (comma-separated list of biome_id=multiplier)");
+        biomeCarverMultipliersRaw = builder.define("biomeCarverMultipliers", "");
         builder.pop();
         strongholdScaling = builder.comment("Enable height rescaling for strongholds")
                                    .define("strongholdScaling", true);
@@ -87,5 +87,17 @@ public class WorldriseConfig {
                            .define("byg", true);
         builder.pop();
         builder.pop();
+    }
+
+    public List<String> getBiomeOreMultiplierEntries() {
+        String raw = biomeOreMultipliersRaw.get();
+        if (raw == null || raw.isBlank()) return List.of();
+        return List.of(raw.split(","));
+    }
+
+    public List<String> getBiomeCarverMultiplierEntries() {
+        String raw = biomeCarverMultipliersRaw.get();
+        if (raw == null || raw.isBlank()) return List.of();
+        return List.of(raw.split(","));
     }
 }

--- a/src/main/java/com/yourorg/worldrise/util/WorldgenScaler.java
+++ b/src/main/java/com/yourorg/worldrise/util/WorldgenScaler.java
@@ -53,16 +53,16 @@ public final class WorldgenScaler {
 
     private static double resolveOreMultiplier(Collection<String> biomeSelectors) {
         return resolveMultiplier(biomeSelectors, WorldriseConfig.INSTANCE.defaultOreMultiplier.get(),
-                WorldriseConfig.INSTANCE.biomeOreMultipliers.get());
+                WorldriseConfig.INSTANCE.getBiomeOreMultiplierEntries());
     }
 
     private static double resolveCarverMultiplier(Collection<String> biomeSelectors) {
         return resolveMultiplier(biomeSelectors, WorldriseConfig.INSTANCE.defaultCarverMultiplier.get(),
-                WorldriseConfig.INSTANCE.biomeCarverMultipliers.get());
+                WorldriseConfig.INSTANCE.getBiomeCarverMultiplierEntries());
     }
 
     private static double resolveMultiplier(Collection<String> biomeSelectors, double defaultMultiplier,
-            List<? extends String> overrides) {
+            List<String> overrides) {
         Map<String, Double> overrideMap = parseOverrides(overrides);
         if (biomeSelectors != null) {
             for (String selector : biomeSelectors) {

--- a/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
+++ b/src/main/java/net/neoforged/neoforge/common/ModConfigSpec.java
@@ -20,6 +20,10 @@ public class ModConfigSpec {
             return new BooleanValue(defaultValue);
         }
 
+        public ConfigValue<String> define(String key, String defaultValue) {
+            return new ConfigValue<>(defaultValue);
+        }
+
         public DoubleValue defineInRange(String key, double defaultValue, double minValue, double maxValue) {
             double clamped = Math.max(minValue, Math.min(maxValue, defaultValue));
             return new DoubleValue(clamped);
@@ -31,7 +35,7 @@ public class ModConfigSpec {
     }
 
     public static class BooleanValue implements Supplier<Boolean> {
-        private final boolean value;
+        private boolean value;
 
         private BooleanValue(boolean value) {
             this.value = value;
@@ -45,10 +49,14 @@ public class ModConfigSpec {
         public boolean getAsBoolean() {
             return value;
         }
+
+        public void set(boolean value) {
+            this.value = value;
+        }
     }
 
     public static class DoubleValue implements Supplier<Double> {
-        private final double value;
+        private double value;
 
         private DoubleValue(double value) {
             this.value = value;
@@ -61,6 +69,27 @@ public class ModConfigSpec {
 
         public double getAsDouble() {
             return value;
+        }
+
+        public void set(double value) {
+            this.value = value;
+        }
+    }
+
+    public static class ConfigValue<T> implements Supplier<T> {
+        private T value;
+
+        private ConfigValue(T value) {
+            this.value = value;
+        }
+
+        @Override
+        public T get() {
+            return value;
+        }
+
+        public void set(T value) {
+            this.value = value;
         }
     }
 }

--- a/src/test/java/com/yourorg/worldrise/data/BiomeModifierLoaderTest.java
+++ b/src/test/java/com/yourorg/worldrise/data/BiomeModifierLoaderTest.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonObject;
 import com.yourorg.worldrise.config.WorldriseConfig;
 import com.yourorg.worldrise.data.BiomeModifierLoader.ScaledModifier;
 import java.nio.file.Path;
-import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,16 +19,16 @@ class BiomeModifierLoaderTest {
 
     private double defaultOre;
     private double defaultCarver;
-    private List<String> oreOverrides;
-    private List<String> carverOverrides;
+    private String oreOverrides;
+    private String carverOverrides;
 
     @BeforeEach
     void snapshotConfig() {
         WorldriseConfig config = WorldriseConfig.INSTANCE;
         defaultOre = config.defaultOreMultiplier.get();
         defaultCarver = config.defaultCarverMultiplier.get();
-        oreOverrides = List.copyOf(config.biomeOreMultipliers.get());
-        carverOverrides = List.copyOf(config.biomeCarverMultipliers.get());
+        oreOverrides = config.biomeOreMultipliersRaw.get();
+        carverOverrides = config.biomeCarverMultipliersRaw.get();
     }
 
     @AfterEach
@@ -37,16 +36,16 @@ class BiomeModifierLoaderTest {
         WorldriseConfig config = WorldriseConfig.INSTANCE;
         config.defaultOreMultiplier.set(defaultOre);
         config.defaultCarverMultiplier.set(defaultCarver);
-        config.biomeOreMultipliers.set(oreOverrides);
-        config.biomeCarverMultipliers.set(carverOverrides);
+        config.biomeOreMultipliersRaw.set(oreOverrides);
+        config.biomeCarverMultipliersRaw.set(carverOverrides);
     }
 
     @Test
     @DisplayName("Ore overrides apply to placed feature placement counts")
     void oreOverridesApplyToPlacedFeatures() throws Exception {
         WorldriseConfig.INSTANCE.defaultOreMultiplier.set(2.0);
-        WorldriseConfig.INSTANCE.biomeOreMultipliers
-                .set(List.of("#worldrise:ores_overworld_biomes=0.5"));
+        WorldriseConfig.INSTANCE.biomeOreMultipliersRaw
+                .set("#worldrise:ores_overworld_biomes=0.5");
 
         ScaledModifier scaled = BiomeModifierLoader.loadScaledModifier(RESOURCE_ROOT, "add_scaled_ores");
         assertEquals(7, scaled.placedFeatures().size(),
@@ -62,7 +61,7 @@ class BiomeModifierLoaderTest {
     @DisplayName("Default multiplier is used when no ore override matches")
     void defaultOreMultiplierUsedWhenNoOverrideMatches() throws Exception {
         WorldriseConfig.INSTANCE.defaultOreMultiplier.set(2.0);
-        WorldriseConfig.INSTANCE.biomeOreMultipliers.set(List.of());
+        WorldriseConfig.INSTANCE.biomeOreMultipliersRaw.set("");
 
         ScaledModifier scaled = BiomeModifierLoader.loadScaledModifier(RESOURCE_ROOT, "add_scaled_ores");
         JsonObject coalFeature = scaled.placedFeatures().get("worldrise:ore_coal_scaled");
@@ -74,8 +73,8 @@ class BiomeModifierLoaderTest {
     @DisplayName("Carver overrides adjust configured carver probability")
     void carverOverridesApplyProbabilityScaling() throws Exception {
         WorldriseConfig.INSTANCE.defaultCarverMultiplier.set(0.5);
-        WorldriseConfig.INSTANCE.biomeCarverMultipliers
-                .set(List.of("#worldrise:ocean_like=2.0"));
+        WorldriseConfig.INSTANCE.biomeCarverMultipliersRaw
+                .set("#worldrise:ocean_like=2.0");
 
         ScaledModifier scaled = BiomeModifierLoader.loadScaledModifier(RESOURCE_ROOT, "add_ocean_canyon");
         JsonObject carver = scaled.configuredCarvers().get("worldrise:ocean_canyon");


### PR DESCRIPTION
## Summary
- replace biome multiplier config entries with comma-separated string values and expose parsing helpers
- update scaler logic, unit tests, and the bundled config/documentation to use the new format
- extend the local ModConfigSpec stub to support string config values and mutation

## Testing
- ./gradlew build -x neoFormJoined1.21.1-20240808.144430DownloadAssets --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dca8121c688327938bdf0a5229817d