### PR TITLE
Add Moonrise compatibility toggle and detection

### DIFF
--- a/config/worldrise.toml
+++ b/config/worldrise.toml
@@ -16,6 +16,9 @@ endScaling = true
 tectonicEnabled = true
 lithoEnabled = true
 
+[worldrise.compat]
+moonriseCompatEnabled = true
+
 [worldrise.scaling]
 defaultOreMultiplier = 1.0
 defaultCarverMultiplier = 1.0

--- a/src/main/java/com/yourorg/worldrise/Worldrise.java
+++ b/src/main/java/com/yourorg/worldrise/Worldrise.java
@@ -1,14 +1,27 @@
 package com.yourorg.worldrise;
 
 import com.cyberday1.theexpanse.MixinCompatBootstrap;
+import com.yourorg.worldrise.config.WorldriseConfig;
 import com.yourorg.worldrise.vendor.VendoredWorldgen;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Mod("worldrise")
 public final class Worldrise {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Worldrise.class);
+
     public Worldrise(ModContainer container) {
         MixinCompatBootstrap.enforce();
         VendoredWorldgen.init(container);
+        if (isMoonriseActive(WorldriseConfig.INSTANCE)) {
+            LOGGER.info("Moonrise detected. Worldrise will avoid chunk pipeline interference.");
+        }
+    }
+
+    public static boolean isMoonriseActive(WorldriseConfig config) {
+        return config.moonriseCompatEnabled.get() && ModList.get().isLoaded("moonrise");
     }
 }

--- a/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
+++ b/src/main/java/com/yourorg/worldrise/config/WorldriseConfig.java
@@ -27,6 +27,7 @@ public class WorldriseConfig {
     public final ModConfigSpec.BooleanValue endScaling;
     public final ModConfigSpec.BooleanValue tectonicEnabled;
     public final ModConfigSpec.BooleanValue lithoEnabled;
+    public final ModConfigSpec.BooleanValue moonriseCompatEnabled;
     public final ModConfigSpec.BooleanValue biomesOPlentyCompat;
     public final ModConfigSpec.BooleanValue bygCompat;
 
@@ -80,6 +81,12 @@ public class WorldriseConfig {
                                  .define("tectonicEnabled", true);
         lithoEnabled = builder.comment("Enable vendored lithostitched registry hooks")
                                .define("lithoEnabled", true);
+        builder.push("compat");
+        moonriseCompatEnabled = builder
+                .comment("Enable compatibility checks with Moonrise (optimization mod). "
+                        + "If false, Worldrise ignores Moonrise even if loaded.")
+                .define("moonriseCompatEnabled", true);
+        builder.pop();
         builder.push("compatibility");
         biomesOPlentyCompat = builder.comment("Enable Biomes O' Plenty biome compatibility")
                                      .define("biomesoplenty", true);


### PR DESCRIPTION
## Summary
- add a Moonrise compatibility toggle to the config spec and default `worldrise.toml`
- detect Moonrise at runtime and log when the optimization mod is active

## Testing
- ./gradlew build --stacktrace *(fails: HTTP errors while downloading Minecraft assets)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaef77a948327b02aa7b6856a40c0