### PR TITLE
Adjust overworld sea level to 150

### DIFF
--- a/src/main/resources/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/data/minecraft/dimension_type/overworld.json
@@ -2,6 +2,7 @@
   "min_y": -256,
   "height": 2272,
   "logical_height": 2272,
+  "sea_level": 150,
   "has_skylight": true,
   "effects": "minecraft:overworld",
   "infiniburn": "#minecraft:infiniburn_overworld",

--- a/src/main/resources/data/worldrise/dimension_type/overworld.json
+++ b/src/main/resources/data/worldrise/dimension_type/overworld.json
@@ -2,6 +2,7 @@
   "min_y": -256,
   "height": 2272,
   "logical_height": 2272,
+  "sea_level": 150,
   "has_skylight": true,
   "effects": "minecraft:overworld",
   "infiniburn": "#minecraft:infiniburn_overworld",


### PR DESCRIPTION
## Summary
- set the overworld sea level to 150 for both the Worldrise and vanilla dimension type overrides

## Testing
- ./gradlew clean build --stacktrace --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dd51ed57b4832798ab5f257ea76b74