### PR TITLE
Ensure Worldrise datapack auto-loads with updated worldgen

### DIFF
--- a/src/main/java/com/yourorg/worldrise/Worldrise.java
+++ b/src/main/java/com/yourorg/worldrise/Worldrise.java
@@ -2,10 +2,12 @@ package com.yourorg.worldrise;
 
 import com.cyberday1.theexpanse.MixinCompatBootstrap;
 import com.yourorg.worldrise.config.WorldriseConfig;
+import com.yourorg.worldrise.datapack.WorldriseDatapackInjector;
 import com.yourorg.worldrise.vendor.VendoredWorldgen;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -16,6 +18,7 @@ public final class Worldrise {
     public Worldrise(ModContainer container) {
         MixinCompatBootstrap.enforce();
         VendoredWorldgen.init(container);
+        NeoForge.EVENT_BUS.addListener(WorldriseDatapackInjector::onServerAboutToStart);
         if (isMoonriseActive(WorldriseConfig.INSTANCE)) {
             LOGGER.info("Moonrise detected. Worldrise will avoid chunk pipeline interference.");
         }

--- a/src/main/java/com/yourorg/worldrise/datapack/WorldriseDatapackInjector.java
+++ b/src/main/java/com/yourorg/worldrise/datapack/WorldriseDatapackInjector.java
@@ -1,0 +1,71 @@
+package com.yourorg.worldrise.datapack;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelResource;
+import net.neoforged.neoforge.event.server.ServerAboutToStartEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+
+public final class WorldriseDatapackInjector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorldriseDatapackInjector.class);
+    private static final String RESOURCE_ROOT = "/data/minecraft/";
+    private static final String PACK_FOLDER_NAME = "Worldrise injected worldgen overrides";
+    private static final List<String> PACK_RESOURCES = List.of(
+            "pack.mcmeta",
+            "dimension_type/overworld.json",
+            "dimension_type/nether.json",
+            "dimension_type/end.json",
+            "worldgen/noise_settings/overworld.json",
+            "worldgen/noise_settings/nether.json",
+            "worldgen/noise_settings/end.json"
+    );
+
+    private WorldriseDatapackInjector() {
+    }
+
+    public static void onServerAboutToStart(ServerAboutToStartEvent event) {
+        MinecraftServer server = event.getServer();
+        Path datapackDir = server.getWorldPath(LevelResource.DATAPACK_DIR);
+        copyIfMissing(datapackDir);
+    }
+
+    public static void copyIfMissing(Path datapackDir) {
+        Path datapackRoot = datapackDir.resolve(PACK_FOLDER_NAME);
+        if (Files.exists(datapackRoot)) {
+            return;
+        }
+
+        try {
+            Files.createDirectories(datapackRoot);
+            for (String relativePath : PACK_RESOURCES) {
+                Path destination = datapackRoot.resolve(relativePath);
+                Path parent = destination.getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+
+                try (InputStream inputStream = WorldriseDatapackInjector.class.getResourceAsStream(RESOURCE_ROOT + relativePath)) {
+                    if (inputStream == null) {
+                        LOGGER.warn("Missing datapack resource: {}", relativePath);
+                        continue;
+                    }
+
+                    Files.copy(inputStream, destination, StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException ioException) {
+                    LOGGER.error("Failed to copy datapack resource {}", relativePath, ioException);
+                }
+            }
+
+            LOGGER.info("Injected Worldrise datapack at {}", datapackRoot);
+        } catch (IOException exception) {
+            LOGGER.error("Failed to prepare datapack directory {}", datapackDir, exception);
+        }
+    }
+}

--- a/src/main/resources/data/minecraft/dimension_type/end.json
+++ b/src/main/resources/data/minecraft/dimension_type/end.json
@@ -15,8 +15,8 @@
   "respawn_anchor_works": false,
   "bed_works": false,
   "effects": "minecraft:the_end",
-  "min_y": -256,
-  "height": 2272,
-  "logical_height": 2272,
+  "min_y": 0,
+  "height": 512,
+  "logical_height": 512,
   "coordinate_scale": 1.0
 }

--- a/src/main/resources/data/minecraft/dimension_type/nether.json
+++ b/src/main/resources/data/minecraft/dimension_type/nether.json
@@ -16,7 +16,7 @@
   "bed_works": false,
   "effects": "minecraft:the_nether",
   "min_y": -256,
-  "height": 2272,
-  "logical_height": 2272,
+  "height": 512,
+  "logical_height": 512,
   "coordinate_scale": 8.0
 }

--- a/src/main/resources/data/minecraft/pack.mcmeta
+++ b/src/main/resources/data/minecraft/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Worldrise injected worldgen overrides (Overworld, Nether, End)"
+  }
+}

--- a/src/main/resources/data/minecraft/worldgen/noise_settings/end.json
+++ b/src/main/resources/data/minecraft/worldgen/noise_settings/end.json
@@ -9,8 +9,8 @@
   "disable_mob_generation": true,
   "legacy_random_source": true,
   "noise": {
-    "height": 2272,
-    "min_y": -256,
+    "height": 512,
+    "min_y": 0,
     "size_horizontal": 2,
     "size_vertical": 1
   },

--- a/src/main/resources/data/minecraft/worldgen/noise_settings/nether.json
+++ b/src/main/resources/data/minecraft/worldgen/noise_settings/nether.json
@@ -12,7 +12,7 @@
   "disable_mob_generation": false,
   "legacy_random_source": true,
   "noise": {
-    "height": 2272,
+    "height": 512,
     "min_y": -256,
     "size_horizontal": 1,
     "size_vertical": 2

--- a/src/main/resources/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/src/main/resources/data/minecraft/worldgen/noise_settings/overworld.json
@@ -336,7 +336,7 @@
     }
   },
   "ore_veins_enabled": true,
-  "sea_level": 1200,
+  "sea_level": 150,
   "spawn_target": [
     {
       "continentalness": [

--- a/src/main/resources/data/worldrise/dimension_type/end.json
+++ b/src/main/resources/data/worldrise/dimension_type/end.json
@@ -15,8 +15,8 @@
   "respawn_anchor_works": false,
   "bed_works": false,
   "effects": "minecraft:the_end",
-  "min_y": -256,
-  "height": 2272,
-  "logical_height": 2272,
+  "min_y": 0,
+  "height": 512,
+  "logical_height": 512,
   "coordinate_scale": 1.0
 }

--- a/src/main/resources/data/worldrise/dimension_type/nether.json
+++ b/src/main/resources/data/worldrise/dimension_type/nether.json
@@ -16,7 +16,7 @@
   "bed_works": false,
   "effects": "minecraft:the_nether",
   "min_y": -256,
-  "height": 2272,
-  "logical_height": 2272,
+  "height": 512,
+  "logical_height": 512,
   "coordinate_scale": 8.0
 }


### PR DESCRIPTION
## Summary
- add a datapack injector that copies Worldrise's bundled worldgen overrides into the world's datapack directory when the server starts
- provide the datapack metadata and move the Overworld, Nether, and End overrides into the minecraft namespace with the updated height and sea level values
- update the worldrise dimension type definitions to stay in sync with the injected settings

## Testing
- ./gradlew compileJava

------
https://chatgpt.com/codex/tasks/task_e_68dd5efdeed08327b67cd24d8c6b4162