### PR TITLE
Update overworld dimension validation

### DIFF
--- a/src/test/java/com/yourorg/worldrise/test/WorldriseDimensionValidationTest.java
+++ b/src/test/java/com/yourorg/worldrise/test/WorldriseDimensionValidationTest.java
@@ -4,26 +4,40 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.Test;
 
-import java.io.InputStreamReader;
-import java.io.InputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class WorldriseDimensionValidationTest {
 
-    private JsonObject loadJson(String path) throws Exception {
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream(path)) {
-            assertNotNull(in, "Missing resource: " + path);
-            return JsonParser.parseReader(new InputStreamReader(in)).getAsJsonObject();
-        }
+    private JsonObject loadJson(String resourcePath) throws IOException {
+        Path path = Paths.get("src/main/resources").resolve(resourcePath);
+        assertTrue(Files.exists(path), "Missing resource: " + path);
+        return JsonParser.parseReader(Files.newBufferedReader(path)).getAsJsonObject();
     }
 
     @Test
     public void testOverworldDimensionType() throws Exception {
-        JsonObject json = loadJson("data/worldrise/dimension_type/overworld.json");
-        assertEquals(-256, json.get("min_y").getAsInt(), "Overworld min_y must be -256");
-        assertEquals(2272, json.get("height").getAsInt(), "Overworld height must be 2272");
-        assertEquals(2272, json.get("logical_height").getAsInt(), "Overworld logical_height must be 2272");
+        JsonObject json = loadJson("data/minecraft/dimension_type/overworld.json");
+        int minY = json.get("min_y").getAsInt();
+        int height = json.get("height").getAsInt();
+        int logicalHeight = json.get("logical_height").getAsInt();
+        int seaLevel = json.get("sea_level").getAsInt();
+
+        try {
+            assertEquals(-256, minY, "Overworld min_y must be -256");
+            assertEquals(2272, height, "Overworld height must be 2272");
+            assertEquals(2272, logicalHeight, "Overworld logical_height must be 2272");
+            assertEquals(150, seaLevel, "Overworld sea_level must be 150");
+        } catch (AssertionError e) {
+            System.err.println("Dimension JSON mismatch:");
+            System.err.printf("min_y=%d, height=%d, logical_height=%d, sea_level=%d%n",
+                    minY, height, logicalHeight, seaLevel);
+            throw e;
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- load overworld dimension JSON from the datapack path under the minecraft namespace
- assert updated dimension bounds and log actual values when mismatches occur

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7069a1d883278c2c7afc32fb71bd