### PR TITLE
Add sanity tests for dimension datapack bounds

### DIFF
--- a/src/test/java/com/yourorg/worldrise/WorldriseDimensionSanityTest.java
+++ b/src/test/java/com/yourorg/worldrise/WorldriseDimensionSanityTest.java
@@ -1,0 +1,47 @@
+package com.yourorg.worldrise;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class WorldriseDimensionSanityTest {
+    private static final Gson GSON = new Gson();
+
+    private JsonObject loadResource(String path) {
+        InputStream in = getClass().getClassLoader().getResourceAsStream(path);
+        assertNotNull(in, "Missing resource: " + path);
+        return GSON.fromJson(new InputStreamReader(in), JsonObject.class);
+    }
+
+    @Test
+    void testOverworldBounds() {
+        JsonObject obj = loadResource("data/minecraft/dimension_type/overworld.json");
+        assertEquals(-256, obj.get("min_y").getAsInt());
+        assertEquals(2272, obj.get("height").getAsInt());
+        assertEquals(2272, obj.get("logical_height").getAsInt());
+        assertEquals(150, obj.get("sea_level").getAsInt());
+    }
+
+    @Test
+    void testNetherBounds() {
+        JsonObject obj = loadResource("data/minecraft/dimension_type/the_nether.json");
+        assertEquals(-256, obj.get("min_y").getAsInt());
+        assertEquals(2272, obj.get("height").getAsInt());
+        assertEquals(2272, obj.get("logical_height").getAsInt());
+        assertEquals(32, obj.get("sea_level").getAsInt());
+    }
+
+    @Test
+    void testEndBounds() {
+        JsonObject obj = loadResource("data/minecraft/dimension_type/the_end.json");
+        assertEquals(-256, obj.get("min_y").getAsInt());
+        assertEquals(2272, obj.get("height").getAsInt());
+        assertEquals(2272, obj.get("logical_height").getAsInt());
+        assertEquals(0, obj.get("sea_level").getAsInt());
+    }
+}


### PR DESCRIPTION
## Summary
- add a JUnit sanity test that loads the builtin Overworld, Nether, and End dimension JSONs
- assert the expected min height, total height, logical height, and sea level for each dimension

## Testing
- `./gradlew test` *(fails: DimensionLoaderTest currently failing in main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8caadd3c8327a177f0a5be57e655