### PR TITLE
Ensure mixin compatibility bootstrap runs during class loading

### DIFF
--- a/src/main/java/com/theexpanse/TheExpanse.java
+++ b/src/main/java/com/theexpanse/TheExpanse.java
@@ -1,6 +1,5 @@
 package com.theexpanse;
 
-import com.theexpanse.mixin.MixinCompatBootstrap;
 import com.theexpanse.config.TheExpanseConfig;
 import com.theexpanse.vendor.VendoredWorldgen;
 import java.util.Optional;
@@ -27,11 +26,14 @@ public final class TheExpanse {
     private static final Component BUILTIN_PACK_TITLE = Component.literal("The Expanse Datapack");
     private static final Logger LOGGER = LoggerFactory.getLogger(TheExpanse.class);
 
+    static {
+        com.theexpanse.mixin.MixinCompatBootstrap.apply();
+    }
+
     private final ModContainer modContainer;
 
     public TheExpanse(ModContainer container) {
         this.modContainer = container;
-        MixinCompatBootstrap.apply();
         VendoredWorldgen.init(container);
         NeoForge.EVENT_BUS.addListener(this::registerBuiltinDatapack);
         if (isMoonriseActive(TheExpanseConfig.INSTANCE)) {

--- a/src/main/java/com/theexpanse/mixin/MixinCompatBootstrap.java
+++ b/src/main/java/com/theexpanse/mixin/MixinCompatBootstrap.java
@@ -4,9 +4,9 @@ import org.spongepowered.asm.mixin.MixinEnvironment;
 
 public class MixinCompatBootstrap {
     public static void apply() {
-        MixinEnvironment.CompatibilityLevel level = MixinEnvironment.CompatibilityLevel.JAVA_21;
-        if (MixinEnvironment.getCompatibilityLevel().compareTo(level) < 0) {
-            MixinEnvironment.setCompatibilityLevel(level);
+        MixinEnvironment.CompatibilityLevel target = MixinEnvironment.CompatibilityLevel.JAVA_21;
+        if (MixinEnvironment.getCompatibilityLevel().compareTo(target) < 0) {
+            MixinEnvironment.setCompatibilityLevel(target);
         }
     }
 }


### PR DESCRIPTION
## Summary
- invoke the mixin compatibility bootstrap from a static initializer so it runs when the mod class loads
- keep the mixin bootstrap logic focused on enforcing JAVA_21 compatibility level only when needed

## Testing
- ./gradlew clean build --console=plain *(fails: unable to download Minecraft assets in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc4baf40c8327886b9e0207788b7b