### PR TITLE
Add transformation service to enforce Java 21 mixin compatibility

### DIFF
--- a/src/main/java/com/theexpanse/bootstrap/Java21CompatService.java
+++ b/src/main/java/com/theexpanse/bootstrap/Java21CompatService.java
@@ -1,0 +1,39 @@
+package com.theexpanse.bootstrap;
+
+import cpw.mods.modlauncher.api.IEnvironment;
+import cpw.mods.modlauncher.api.ITransformationService;
+import cpw.mods.modlauncher.api.ITransformer;
+import cpw.mods.modlauncher.api.IncompatibleEnvironmentException;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+
+import java.util.List;
+import java.util.Set;
+
+public class Java21CompatService implements ITransformationService {
+    @Override
+    public String name() {
+        return "the_expanse_java21_compat";
+    }
+
+    @Override
+    public void initialize(IEnvironment environment) {
+        try {
+            MixinEnvironment.CompatibilityLevel target = MixinEnvironment.CompatibilityLevel.JAVA_21;
+            if (MixinEnvironment.getCompatibilityLevel().compareTo(target) < 0) {
+                MixinEnvironment.setCompatibilityLevel(target);
+            }
+        } catch (Throwable t) {
+            // ignore; MixinEnvironment may not be initialized yet
+        }
+    }
+
+    @Override
+    public void onLoad(IEnvironment env, Set<String> otherServices) throws IncompatibleEnvironmentException {
+        // no-op
+    }
+
+    @Override
+    public List<? extends ITransformer<?>> transformers() {
+        return List.of();
+    }
+}

--- a/src/main/resources/META-INF/services/cpw.mods.modlauncher.api.ITransformationService
+++ b/src/main/resources/META-INF/services/cpw.mods.modlauncher.api.ITransformationService
@@ -1,0 +1,1 @@
+com.theexpanse.bootstrap.Java21CompatService


### PR DESCRIPTION
## Summary
- add a ModLauncher transformation service that forces the Mixin environment to use JAVA_21 compatibility during bootstrap
- register the transformation service through the ModLauncher services manifest so it loads before mixin configs

## Testing
- `./gradlew clean build --console=plain` *(fails: unable to download Minecraft asset archives from resources.download.minecraft.net)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc979fdcc832791523df932fcc733