### PR TITLE
Fix builtin datapack registration by adding metadata

### DIFF
--- a/src/main/java/com/theexpanse/data/ExpanseDataPackInjector.java
+++ b/src/main/java/com/theexpanse/data/ExpanseDataPackInjector.java
@@ -1,11 +1,15 @@
 package com.theexpanse.data;
 
 import com.theexpanse.TheExpanse;
+import java.nio.file.Path;
 import java.util.Optional;
 import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.PackLocationInfo;
 import net.minecraft.server.packs.PackSelectionConfig;
 import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.PathPackResources;
+import net.minecraft.server.packs.repository.BuiltInPackSource;
 import net.minecraft.server.packs.repository.KnownPack;
 import net.minecraft.server.packs.repository.Pack;
 import net.minecraft.server.packs.repository.PackSource;
@@ -13,15 +17,12 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
-import net.neoforged.neoforge.resource.ResourcePackLoader;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-@EventBusSubscriber(modid = TheExpanse.MOD_ID)
+@EventBusSubscriber(modid = TheExpanse.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
 public final class ExpanseDataPackInjector {
-    private static final Logger LOGGER = LogManager.getLogger();
-    private static final String BUILTIN_PACK_ID = "mod/" + TheExpanse.MOD_ID;
-    private static final Component BUILTIN_PACK_TITLE = Component.literal("The Expanse Datapack");
+    private static final String BUILTIN_PACK_ID = "the_expanse_builtin";
+    private static final Component BUILTIN_PACK_TITLE = Component.literal("The Expanse Builtin");
+    private static final ResourceLocation BUILTIN_PACK_LOCATION = ResourceLocation.fromNamespaceAndPath(TheExpanse.MOD_ID, "the_expanse");
 
     private ExpanseDataPackInjector() {
     }
@@ -32,8 +33,8 @@ public final class ExpanseDataPackInjector {
             return;
         }
 
-        ModList.get().getModContainerById(TheExpanse.MOD_ID).ifPresentOrElse(container -> {
-            var modInfo = container.getModInfo();
+        ModList.get().getModContainerById(TheExpanse.MOD_ID).ifPresent(modContainer -> {
+            var modInfo = modContainer.getModInfo();
             var packLocationInfo = new PackLocationInfo(
                     BUILTIN_PACK_ID,
                     BUILTIN_PACK_TITLE,
@@ -41,23 +42,23 @@ public final class ExpanseDataPackInjector {
                     Optional.of(new KnownPack(TheExpanse.MOD_ID, BUILTIN_PACK_ID, modInfo.getVersion().toString()))
             );
 
-            ResourcePackLoader.getPackFor(TheExpanse.MOD_ID).ifPresentOrElse(resourcesSupplier -> {
-                event.addRepositorySource(repository -> {
-                    var pack = Pack.readMetaAndCreate(
-                            packLocationInfo,
-                            resourcesSupplier,
-                            PackType.SERVER_DATA,
-                            new PackSelectionConfig(true, Pack.Position.TOP, false)
-                    );
+            Path resourcePath = modInfo.getOwningFile().getFile().findResource(BUILTIN_PACK_LOCATION.getPath());
+            if (resourcePath == null) {
+                return;
+            }
 
-                    if (pack != null) {
-                        repository.accept(pack);
-                        LOGGER.info("Injected The Expanse builtin datapack at TOP priority");
-                    } else {
-                        LOGGER.warn("Failed to create The Expanse builtin datapack pack instance");
-                    }
-                });
-            }, () -> LOGGER.warn("The Expanse pack resources were not discovered; builtin datapack will not be registered"));
-        }, () -> LOGGER.warn("The Expanse mod container was not found; builtin datapack will not be registered"));
+            event.addRepositorySource(consumer -> {
+                Pack pack = Pack.readMetaAndCreate(
+                        packLocationInfo,
+                        BuiltInPackSource.fromName(info -> new PathPackResources(info, resourcePath)),
+                        PackType.SERVER_DATA,
+                        new PackSelectionConfig(true, Pack.Position.TOP, false)
+                );
+
+                if (pack != null) {
+                    consumer.accept(pack);
+                }
+            });
+        });
     }
 }


### PR DESCRIPTION
## Summary
- add the missing `pack.mcmeta` so the builtin datapack is discoverable
- update `ExpanseDataPackInjector` to point at the new classpath root and register the pack at top priority

## Testing
- `./gradlew clean build --console=plain` *(fails: HTTP 403 downloading Minecraft assets in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddd54283308327ba016edbf9e27c33