### PR TITLE
Update data pack injector annotation

### DIFF
--- a/src/main/java/com/theexpanse/data/ExpanseDataPackInjector.java
+++ b/src/main/java/com/theexpanse/data/ExpanseDataPackInjector.java
@@ -18,7 +18,7 @@ import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.AddPackFindersEvent;
 
-@EventBusSubscriber(modid = TheExpanse.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+@EventBusSubscriber(modid = TheExpanse.MOD_ID)
 public final class ExpanseDataPackInjector {
     private static final String BUILTIN_PACK_ID = "the_expanse_builtin";
     private static final Component BUILTIN_PACK_TITLE = Component.literal("The Expanse Builtin");


### PR DESCRIPTION
## Summary
- update `ExpanseDataPackInjector` to use the default mod event bus in the NeoForge `@EventBusSubscriber` annotation, removing the deprecated bus argument

## Testing
- ./gradlew --no-daemon clean build --console=plain *(hangs while downloading NeoForge assets; aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68dde1261f6883279a1d65f94e7f0365