### PR TITLE
Restore builtin datapack overrides for vanilla dimensions

### DIFF
--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
@@ -1,22 +1,24 @@
 {
   "ultrawarm": false,
   "natural": true,
-  "coordinate_scale": 1.0,
   "piglin_safe": false,
-  "bed_works": true,
   "respawn_anchor_works": false,
+  "bed_works": true,
   "has_raids": true,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "coordinate_scale": 1.0,
+  "ambient_light": 0.0,
   "min_y": -256,
-  "height": 2272,
-  "logical_height": 2272,
+  "height": 2304,
+  "logical_height": 2304,
   "infiniburn": "#minecraft:infiniburn_overworld",
   "effects": "minecraft:overworld",
-  "ambient_light": 0.0,
   "monster_spawn_light_level": {
     "type": "minecraft:uniform",
-    "value": 0
+    "value": 7
   },
   "monster_spawn_block_light_limit": 0,
-  "has_skylight": true,
+  "fixed_time": null,
   "sea_level": 150
 }

--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/the_end.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/the_end.json
@@ -1,22 +1,21 @@
 {
-  "piglin_safe": false,
-  "natural": false,
-  "ambient_light": 0.0,
-  "has_skylight": false,
-  "has_ceiling": false,
   "ultrawarm": false,
-  "has_raids": false,
-  "monster_spawn_light_level": {
-    "type": "minecraft:uniform",
-    "value": 7
-  },
-  "monster_spawn_block_light_limit": 0,
-  "infiniburn": "#minecraft:infiniburn_end",
+  "natural": false,
+  "piglin_safe": false,
   "respawn_anchor_works": false,
   "bed_works": false,
+  "has_raids": false,
+  "has_skylight": false,
+  "has_ceiling": false,
+  "coordinate_scale": 1.0,
+  "ambient_light": 0.0,
+  "min_y": -256,
+  "height": 2304,
+  "logical_height": 2304,
+  "infiniburn": "#minecraft:infiniburn_end",
   "effects": "minecraft:the_end",
-  "min_y": 0,
-  "height": 512,
-  "logical_height": 512,
-  "coordinate_scale": 1.0
+  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 0,
+  "fixed_time": 6000,
+  "sea_level": 150
 }

--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/the_nether.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/the_nether.json
@@ -1,22 +1,21 @@
 {
-  "piglin_safe": true,
-  "natural": false,
-  "ambient_light": 0.1,
-  "has_skylight": false,
-  "has_ceiling": true,
   "ultrawarm": true,
-  "has_raids": false,
-  "monster_spawn_light_level": {
-    "type": "minecraft:uniform",
-    "value": 7
-  },
-  "monster_spawn_block_light_limit": 15,
-  "infiniburn": "#minecraft:infiniburn_nether",
+  "natural": false,
+  "piglin_safe": true,
   "respawn_anchor_works": true,
   "bed_works": false,
-  "effects": "minecraft:the_nether",
+  "has_raids": false,
+  "has_skylight": false,
+  "has_ceiling": true,
+  "coordinate_scale": 8.0,
+  "ambient_light": 0.1,
   "min_y": -256,
-  "height": 512,
-  "logical_height": 512,
-  "coordinate_scale": 8.0
+  "height": 2304,
+  "logical_height": 2304,
+  "infiniburn": "#minecraft:infiniburn_nether",
+  "effects": "minecraft:the_nether",
+  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 15,
+  "fixed_time": 18000,
+  "sea_level": 150
 }

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/overworld.json
@@ -1,20 +1,15 @@
 {
   "sea_level": 150,
-  "disable_mob_generation": false,
-  "aquifers_enabled": true,
-  "ore_veins_enabled": true,
+  "noise": {
+    "min_y": -256,
+    "height": 2304,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
   "default_block": {
     "Name": "minecraft:stone"
   },
   "default_fluid": {
     "Name": "minecraft:water"
-  },
-  "noise": {
-    "min_y": -256,
-    "height": 2272,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "spawn_target": [],
-  "spawn_density": {}
+  }
 }

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_end.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_end.json
@@ -1,20 +1,15 @@
 {
-  "sea_level": 0,
-  "disable_mob_generation": false,
-  "aquifers_enabled": false,
-  "ore_veins_enabled": false,
+  "sea_level": 150,
+  "noise": {
+    "min_y": -256,
+    "height": 2304,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
   "default_block": {
     "Name": "minecraft:end_stone"
   },
   "default_fluid": {
     "Name": "minecraft:air"
-  },
-  "noise": {
-    "min_y": -256,
-    "height": 2272,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "spawn_target": [],
-  "spawn_density": {}
+  }
 }

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_nether.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_nether.json
@@ -1,20 +1,15 @@
 {
-  "sea_level": 32,
-  "disable_mob_generation": false,
-  "aquifers_enabled": false,
-  "ore_veins_enabled": false,
+  "sea_level": 150,
+  "noise": {
+    "min_y": -256,
+    "height": 2304,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
   "default_block": {
     "Name": "minecraft:netherrack"
   },
   "default_fluid": {
     "Name": "minecraft:lava"
-  },
-  "noise": {
-    "min_y": -256,
-    "height": 2272,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "spawn_target": [],
-  "spawn_density": {}
+  }
 }


### PR DESCRIPTION
## Summary
- restore Overworld, Nether, and End `dimension_type` overrides with expanded height, logical height, and sea level
- update the matching `noise_settings` overrides to use the same vertical bounds and fluids/blocks

## Testing
- `./gradlew clean build --console=plain` *(fails: unable to download Minecraft assets from resources.download.minecraft.net in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde91c72e4832786095fe10cfbf43f