### PR TITLE
Align datapack override JSON formatting

### DIFF
--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
@@ -14,10 +14,7 @@
   "logical_height": 2304,
   "infiniburn": "#minecraft:infiniburn_overworld",
   "effects": "minecraft:overworld",
-  "monster_spawn_light_level": {
-    "type": "minecraft:uniform",
-    "value": 7
-  },
+  "monster_spawn_light_level": { "type": "minecraft:uniform", "value": 7 },
   "monster_spawn_block_light_limit": 0,
   "fixed_time": null,
   "sea_level": 150

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/overworld.json
@@ -1,15 +1,6 @@
 {
   "sea_level": 150,
-  "noise": {
-    "min_y": -256,
-    "height": 2304,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "default_block": {
-    "Name": "minecraft:stone"
-  },
-  "default_fluid": {
-    "Name": "minecraft:water"
-  }
+  "noise": { "min_y": -256, "height": 2304, "size_horizontal": 1, "size_vertical": 2 },
+  "default_block": { "Name": "minecraft:stone" },
+  "default_fluid": { "Name": "minecraft:water" }
 }

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_end.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_end.json
@@ -1,15 +1,6 @@
 {
   "sea_level": 150,
-  "noise": {
-    "min_y": -256,
-    "height": 2304,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "default_block": {
-    "Name": "minecraft:end_stone"
-  },
-  "default_fluid": {
-    "Name": "minecraft:air"
-  }
+  "noise": { "min_y": -256, "height": 2304, "size_horizontal": 1, "size_vertical": 2 },
+  "default_block": { "Name": "minecraft:end_stone" },
+  "default_fluid": { "Name": "minecraft:air" }
 }

--- a/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_nether.json
+++ b/src/main/resources/the_expanse/data/minecraft/worldgen/noise_settings/the_nether.json
@@ -1,15 +1,6 @@
 {
   "sea_level": 150,
-  "noise": {
-    "min_y": -256,
-    "height": 2304,
-    "size_horizontal": 1,
-    "size_vertical": 2
-  },
-  "default_block": {
-    "Name": "minecraft:netherrack"
-  },
-  "default_fluid": {
-    "Name": "minecraft:lava"
-  }
+  "noise": { "min_y": -256, "height": 2304, "size_horizontal": 1, "size_vertical": 2 },
+  "default_block": { "Name": "minecraft:netherrack" },
+  "default_fluid": { "Name": "minecraft:lava" }
 }


### PR DESCRIPTION
## Summary
- inline the monster spawn light level definition in the overworld dimension override
- inline noise and default block/fluid objects across the builtin noise setting overrides for overworld, nether, and end

## Testing
- ./gradlew clean build --console=plain -x neoFormJoined1.21.1-20240808.144430DownloadAssets

------
https://chatgpt.com/codex/tasks/task_e_68ddec6a8f448327b7b16c9b113c42f2