### PR TITLE
Add placeholder access transformer and guard task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,3 +86,17 @@ jar {
 tasks.named("test") {
     enabled = false
 }
+
+def applyAccessTransformerClass
+
+try {
+    applyAccessTransformerClass = project.class.classLoader.loadClass('net.neoforged.gradle.dsl.common.tasks.ApplyAccessTransformer')
+} catch (ClassNotFoundException ignored) {
+    applyAccessTransformerClass = null
+}
+
+if (applyAccessTransformerClass != null) {
+    tasks.withType(applyAccessTransformerClass).configureEach {
+        onlyIf { file("src/main/resources/META-INF/accesstransformer.cfg").exists() }
+    }
+}

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,3 @@
+# Empty access transformer file for The Expanse
+# This ensures NeoForge’s AT task has a valid input
+# Leave this file empty unless you need to add AT entries in the future


### PR DESCRIPTION
## Summary
- add an empty access transformer configuration file so NeoForge always has a valid input
- guard the ApplyAccessTransformer task so it only runs when the configuration file exists

## Testing
- ./gradlew clean build --console=plain --stacktrace
- jar tf build/libs/the_expanse-0.1.0.jar | rg "neoforge.mods.toml|mixins.json|pack.mcmeta|TheExpanse.class|MANIFEST.MF"


------
https://chatgpt.com/codex/tasks/task_e_68deafbe6828832782c77ddc9d340e07