### PR TITLE
Add stub worldgen data to resolve registry references

### DIFF
--- a/src/main/resources/data/minecraft/worldgen/configured_feature/ore_coal_upper.json
+++ b/src/main/resources/data/minecraft/worldgen/configured_feature/ore_coal_upper.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.5,
+    "size": 17,
+    "targets": [
+      {
+        "target": "minecraft:stone_ore_replaceables",
+        "state": { "Name": "minecraft:coal_ore" }
+      },
+      {
+        "target": "minecraft:deepslate_ore_replaceables",
+        "state": { "Name": "minecraft:deepslate_coal_ore" }
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper.json
+++ b/src/main/resources/data/minecraft/worldgen/configured_feature/ore_copper.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.2,
+    "size": 14,
+    "targets": [
+      {
+        "target": "minecraft:stone_ore_replaceables",
+        "state": { "Name": "minecraft:copper_ore" }
+      },
+      {
+        "target": "minecraft:deepslate_ore_replaceables",
+        "state": { "Name": "minecraft:deepslate_copper_ore" }
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/minecraft/worldgen/configured_feature/ore_iron_upper.json
+++ b/src/main/resources/data/minecraft/worldgen/configured_feature/ore_iron_upper.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.5,
+    "size": 9,
+    "targets": [
+      {
+        "target": "minecraft:stone_ore_replaceables",
+        "state": { "Name": "minecraft:iron_ore" }
+      },
+      {
+        "target": "minecraft:deepslate_ore_replaceables",
+        "state": { "Name": "minecraft:deepslate_iron_ore" }
+      }
+    ]
+  }
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_additive.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_additive.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 0.0 }

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/entrances.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/entrances.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 0.0 }

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/lava_tunnels.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/lava_tunnels.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 0.0 }

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/pillars.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/pillars.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 0.0 }

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_depth.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_depth.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 62.0 }

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/vertical_scale.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/vertical_scale.json
@@ -1,0 +1,1 @@
+{ "type": "minecraft:constant", "value": 1.0 }


### PR DESCRIPTION
## Summary
- add constant density function stubs for the_expanse worldgen references
- add vanilla configured ore features required by the datapack overrides

## Testing
- ./gradlew clean build


------
https://chatgpt.com/codex/tasks/task_e_68df3ccfde988327854b92dd4bff2f52