### PR TITLE
Ensure constant density function stubs are present

### DIFF
--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_additive.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_additive.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_enabled.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/cheese_enabled.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/depth_cutoff.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/depth_cutoff.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/noodle_additive.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/noodle_additive.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/noodle_enabled.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/noodle_enabled.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/spaghetti_enabled.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/cave/spaghetti_enabled.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/deep_ocean_depth.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/deep_ocean_depth.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/flat_terrain_skew.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/flat_terrain_skew.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/jungle_pillars.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/jungle_pillars.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/lava_tunnels.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/lava_tunnels.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/max_offset.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/max_offset.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/continents.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/continents.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/erosion.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/erosion.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/island_a.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/island_a.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/island_b.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/island_b.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/ridge.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/noise/ridge.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_depth.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_depth.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_offset.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/ocean_offset.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/rolling_hills.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/rolling_hills.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/underground_rivers.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/underground_rivers.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}

--- a/src/main/resources/data/the_expanse/worldgen/density_function/__constants/vertical_scale.json
+++ b/src/main/resources/data/the_expanse/worldgen/density_function/__constants/vertical_scale.json
@@ -1,1 +1,4 @@
-{ "type": "minecraft:constant", "value": 0.0 }
+{
+  "type": "minecraft:constant",
+  "value": 0.0
+}


### PR DESCRIPTION
## Summary
- add constant density function stubs under `data/the_expanse/worldgen/density_function/__constants`
- ensure each stub resolves to a zero-valued `minecraft:constant` density function

## Testing
- ./gradlew clean build

------
https://chatgpt.com/codex/tasks/task_e_68df48369f0883279296813ef18bad35