### PR TITLE
Fix VerticalAnchor y fields in carver configs

### DIFF
--- a/src/main/resources/data/the_expanse/worldgen/configured_carver/mega_ravine.json
+++ b/src/main/resources/data/the_expanse/worldgen/configured_carver/mega_ravine.json
@@ -3,11 +3,10 @@
   "config": {
     "probability": 0.02,
     "y": {
-      "type": "minecraft:uniform",
       "min_inclusive": {
         "absolute": 20
       },
-      "max_exclusive": {
+      "max_inclusive": {
         "absolute": 180
       }
     },

--- a/src/main/resources/data/the_expanse/worldgen/configured_carver/ocean_blue_hole.json
+++ b/src/main/resources/data/the_expanse/worldgen/configured_carver/ocean_blue_hole.json
@@ -3,11 +3,10 @@
   "config": {
     "probability": 0.02,
     "y": {
-      "type": "minecraft:uniform",
       "min_inclusive": {
         "absolute": 10
       },
-      "max_exclusive": {
+      "max_inclusive": {
         "absolute": 180
       }
     },

--- a/src/main/resources/data/the_expanse/worldgen/configured_carver/ocean_canyon.json
+++ b/src/main/resources/data/the_expanse/worldgen/configured_carver/ocean_canyon.json
@@ -3,11 +3,10 @@
   "config": {
     "probability": 0.02,
     "y": {
-      "type": "minecraft:uniform",
       "min_inclusive": {
         "absolute": 10
       },
-      "max_exclusive": {
+      "max_inclusive": {
         "absolute": 180
       }
     },

--- a/src/main/resources/data/the_expanse/worldgen/configured_carver/sinkhole.json
+++ b/src/main/resources/data/the_expanse/worldgen/configured_carver/sinkhole.json
@@ -3,11 +3,10 @@
   "config": {
     "probability": 0.01,
     "y": {
-      "type": "minecraft:uniform",
       "min_inclusive": {
         "absolute": 40
       },
-      "max_exclusive": {
+      "max_inclusive": {
         "absolute": 140
       }
     },


### PR DESCRIPTION
## Summary
- update the y field in each configured carver to use the VerticalAnchor format
- remove the uniform provider type and switch to max_inclusive bounds in all carver y fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e067453d08832788f0d0df60a09add