### PR TITLE
Fix ore removal modifiers to use vanilla IDs

### DIFF
--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_coal.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_coal.json
@@ -1,6 +1,6 @@
 {
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
-  "features": [ "minecraft:ore_coal_upper_placed" ],
+  "features": [ "minecraft:ore_coal_upper" ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_copper.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_copper.json
@@ -2,9 +2,9 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_copper_placed",
-    "minecraft:ore_copper_large_placed",
-    "minecraft:ore_copper_small_placed"
+    "minecraft:ore_copper",
+    "minecraft:ore_copper_large",
+    "minecraft:ore_copper_small"
   ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_diamond.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_diamond.json
@@ -2,10 +2,10 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_diamond_placed",
-    "minecraft:ore_diamond_large_placed",
-    "minecraft:ore_diamond_small_placed",
-    "minecraft:ore_diamond_buried_placed"
+    "minecraft:ore_diamond",
+    "minecraft:ore_diamond_large",
+    "minecraft:ore_diamond_small",
+    "minecraft:ore_diamond_buried"
   ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_gold.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_gold.json
@@ -2,9 +2,9 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_gold_placed",
-    "minecraft:ore_gold_extra_placed",
-    "minecraft:ore_gold_lower_placed"
+    "minecraft:ore_gold",
+    "minecraft:ore_gold_extra",
+    "minecraft:ore_gold_lower"
   ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_iron.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_iron.json
@@ -2,9 +2,9 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_iron_upper_placed",
-    "minecraft:ore_iron_middle_placed",
-    "minecraft:ore_iron_small_placed"
+    "minecraft:ore_iron_upper",
+    "minecraft:ore_iron_middle",
+    "minecraft:ore_iron_small"
   ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_lapis.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_lapis.json
@@ -2,8 +2,8 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_lapis_placed",
-    "minecraft:ore_lapis_buried_placed"
+    "minecraft:ore_lapis",
+    "minecraft:ore_lapis_buried"
   ],
   "step": "underground_ores"
 }

--- a/src/main/resources/data/the_expanse/biome_modifier/remove_ore_redstone.json
+++ b/src/main/resources/data/the_expanse/biome_modifier/remove_ore_redstone.json
@@ -2,8 +2,8 @@
   "type": "neoforge:remove_features",
   "biomes": "#minecraft:is_overworld",
   "features": [
-    "minecraft:ore_redstone_placed",
-    "minecraft:ore_redstone_lower_placed"
+    "minecraft:ore_redstone",
+    "minecraft:ore_redstone_lower"
   ],
   "step": "underground_ores"
 }


### PR DESCRIPTION
## Summary
- correct the ore removal biome modifiers to point at the vanilla placed feature IDs without the `_placed` suffix so the registries can load

## Testing
- `./gradlew build` *(fails: requires downloading Minecraft assets, which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e06e1da1308327bc3d05703ef3bfa4