### PR TITLE
Add dimension type overrides for expanded world height

### DIFF
--- a/src/main/resources/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/data/minecraft/dimension_type/overworld.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": false,
+  "natural": true,
+  "coordinate_scale": 1.0,
+  "bed_works": true,
+  "respawn_anchor_works": false,
+  "has_raids": true,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "min_y": -256,
+  "height": 2000,
+  "logical_height": 2000,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "effects": "minecraft:overworld",
+  "piglin_safe": false,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": [0, 7]
+  },
+  "monster_spawn_block_light_limit": 0
+}

--- a/src/main/resources/data/minecraft/dimension_type/the_end.json
+++ b/src/main/resources/data/minecraft/dimension_type/the_end.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": false,
+  "natural": false,
+  "coordinate_scale": 1.0,
+  "bed_works": false,
+  "respawn_anchor_works": false,
+  "has_raids": false,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "ambient_light": 0.0,
+  "min_y": -256,
+  "height": 2000,
+  "logical_height": 2000,
+  "infiniburn": "#minecraft:infiniburn_end",
+  "effects": "minecraft:the_end",
+  "piglin_safe": false,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": [0, 7]
+  },
+  "monster_spawn_block_light_limit": 0
+}

--- a/src/main/resources/data/minecraft/dimension_type/the_nether.json
+++ b/src/main/resources/data/minecraft/dimension_type/the_nether.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": true,
+  "natural": false,
+  "coordinate_scale": 8.0,
+  "bed_works": false,
+  "respawn_anchor_works": true,
+  "has_raids": false,
+  "has_skylight": false,
+  "has_ceiling": true,
+  "ambient_light": 0.1,
+  "min_y": -256,
+  "height": 2000,
+  "logical_height": 2000,
+  "infiniburn": "#minecraft:infiniburn_nether",
+  "effects": "minecraft:the_nether",
+  "piglin_safe": true,
+  "monster_spawn_light_level": {
+    "type": "minecraft:uniform",
+    "value": [0, 7]
+  },
+  "monster_spawn_block_light_limit": 15
+}

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,8 +1,7 @@
-﻿{
+{
   "pack": {
     "description": "The Expanse Resources",
-    "pack_format": 48,
-    "forge:resource_pack_format": 48,
-    "forge:data_pack_format": 48
+    "pack_format": 34,
+    "forge:data_pack_format": 34
   }
 }


### PR DESCRIPTION
## Summary
- add overrides for the overworld, nether, and end dimension types to extend the playable height range to -256..2000
- update the pack metadata to match the data pack format required for the custom dimension definitions

## Testing
- `./gradlew clean build --console=plain` *(fails: asset downloads return HTTP error codes in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08859831c8327b890121a04921c25