### PR TITLE
Update pack metadata formats for 1.21.1

### DIFF
--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -2,6 +2,7 @@
   "pack": {
     "description": "The Expanse Resources",
     "pack_format": 34,
-    "forge:data_pack_format": 34
+    "forge:resource_pack_format": 34,
+    "forge:data_pack_format": 48
   }
 }


### PR DESCRIPTION
## Summary
- update `pack.mcmeta` to include the forge resource pack format entry
- raise the forge data pack format value to 48 for Minecraft 1.21.1 compatibility

## Testing
- ./gradlew clean build --console=plain *(fails: unable to download Minecraft asset resources; HTTP response errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e08a72ab508327b1a8589783e17184