### PR TITLE
Update pack metadata for NeoForge 1.21.1

### DIFF
--- a/src/main/resources/data/the_expanse/pack.mcmeta
+++ b/src/main/resources/data/the_expanse/pack.mcmeta
@@ -1,6 +1,7 @@
 {
   "pack": {
+    "description": "The Expanse worldgen data",
     "pack_format": 48,
-    "description": "The Expanse worldgen data"
+    "forge:data_pack_format": 48
   }
 }


### PR DESCRIPTION
## Summary
- ensure the bundled worldgen data pack advertises forge:data_pack_format 48 for NeoForge 1.21.1

## Testing
- `./gradlew clean build --console=plain` *(fails: unable to download Minecraft assets due to HTTP errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e08b9dad8483278251327eaea01dc7