### PR TITLE
Add expanded noise settings and runtime debug logging

### DIFF
--- a/src/main/java/com/theexpanse/TheExpanse.java
+++ b/src/main/java/com/theexpanse/TheExpanse.java
@@ -2,6 +2,11 @@ package com.theexpanse;
 
 import com.theexpanse.data.worldgen.processor.TheExpanseProcessors;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.dimension.DimensionType;
+import net.minecraft.world.level.levelgen.NoiseBasedChunkGenerator;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforge.common.NeoForge;
@@ -25,7 +30,32 @@ public class TheExpanse {
     }
 
     private void onServerStarted(ServerStartedEvent event) {
-        var access = event.getServer().registryAccess();
+        MinecraftServer server = event.getServer();
+
+        server.registryAccess()
+              .registryOrThrow(Registries.LEVEL_STEM)
+              .entrySet()
+              .forEach(entry -> {
+                  var stem = entry.getValue();
+                  DimensionType type = stem.type().value();
+                  ResourceLocation dimensionTypeId = stem.type().unwrapKey()
+                      .map(ResourceKey::location)
+                      .orElse(null);
+                  ResourceLocation noise = null;
+                  if (stem.generator() instanceof NoiseBasedChunkGenerator noiseGenerator) {
+                      noise = noiseGenerator.generatorSettings().unwrapKey()
+                          .map(ResourceKey::location)
+                          .orElse(null);
+                  }
+                  ResourceLocation displayId = dimensionTypeId != null ? dimensionTypeId : entry.getKey().location();
+                  System.out.println("[TheExpanse][Debug] DimensionType " + displayId +
+                      " -> noise_settings=" + (noise == null ? "null" : noise.toString()) +
+                      " min_y=" + type.minY() +
+                      " height=" + type.height() +
+                      " logical_height=" + type.logicalHeight());
+              });
+
+        var access = server.registryAccess();
 
         // Dump density functions
         var dfRegistry = access.registryOrThrow(Registries.DENSITY_FUNCTION);

--- a/src/main/resources/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/data/minecraft/dimension_type/overworld.json
@@ -19,5 +19,6 @@
     "min_inclusive": 0,
     "max_inclusive": 7
   },
-  "monster_spawn_block_light_limit": 0
+  "monster_spawn_block_light_limit": 0,
+  "noise_settings": "the_expanse:overworld"
 }

--- a/src/main/resources/data/minecraft/dimension_type/the_end.json
+++ b/src/main/resources/data/minecraft/dimension_type/the_end.json
@@ -19,5 +19,6 @@
     "min_inclusive": 0,
     "max_inclusive": 7
   },
-  "monster_spawn_block_light_limit": 0
+  "monster_spawn_block_light_limit": 0,
+  "noise_settings": "the_expanse:the_end"
 }

--- a/src/main/resources/data/minecraft/dimension_type/the_nether.json
+++ b/src/main/resources/data/minecraft/dimension_type/the_nether.json
@@ -19,5 +19,6 @@
     "min_inclusive": 0,
     "max_inclusive": 7
   },
-  "monster_spawn_block_light_limit": 15
+  "monster_spawn_block_light_limit": 15,
+  "noise_settings": "the_expanse:the_nether"
 }

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/overworld.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/overworld.json
@@ -1,0 +1,20 @@
+{
+  "sea_level": 150,
+  "disable_mob_generation": false,
+  "noise_caves_enabled": true,
+  "aquifers_enabled": true,
+  "ore_veins_enabled": true,
+  "use_legacy_random_source": false,
+  "default_block": { "Name": "minecraft:stone" },
+  "default_fluid": { "Name": "minecraft:water" },
+  "noise": {
+    "min_y": -256,
+    "height": 2000,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
+  "noise_router": "minecraft:overworld",
+  "surface_rule": "minecraft:overworld",
+  "spawn_target": "minecraft:overworld",
+  "spawn_target_probability": 0.1
+}

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/the_end.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/the_end.json
@@ -1,0 +1,20 @@
+{
+  "sea_level": 150,
+  "disable_mob_generation": false,
+  "noise_caves_enabled": false,
+  "aquifers_enabled": false,
+  "ore_veins_enabled": false,
+  "use_legacy_random_source": false,
+  "default_block": { "Name": "minecraft:end_stone" },
+  "default_fluid": { "Name": "minecraft:air" },
+  "noise": {
+    "min_y": -256,
+    "height": 2000,
+    "size_horizontal": 2,
+    "size_vertical": 1
+  },
+  "noise_router": "minecraft:end",
+  "surface_rule": "minecraft:end",
+  "spawn_target": "minecraft:end",
+  "spawn_target_probability": 0.1
+}

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/the_nether.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/the_nether.json
@@ -1,0 +1,20 @@
+{
+  "sea_level": 150,
+  "disable_mob_generation": false,
+  "noise_caves_enabled": true,
+  "aquifers_enabled": false,
+  "ore_veins_enabled": false,
+  "use_legacy_random_source": false,
+  "default_block": { "Name": "minecraft:netherrack" },
+  "default_fluid": { "Name": "minecraft:lava" },
+  "noise": {
+    "min_y": -256,
+    "height": 2000,
+    "size_horizontal": 1,
+    "size_vertical": 2
+  },
+  "noise_router": "minecraft:nether",
+  "surface_rule": "minecraft:nether",
+  "spawn_target": "minecraft:nether",
+  "spawn_target_probability": 0.1
+}

--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/overworld.json
@@ -17,5 +17,6 @@
   "monster_spawn_light_level": { "type": "minecraft:uniform", "value": 7 },
   "monster_spawn_block_light_limit": 0,
   "fixed_time": null,
-  "sea_level": 150
+  "sea_level": 150,
+  "noise_settings": "the_expanse:overworld"
 }

--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/the_end.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/the_end.json
@@ -17,5 +17,6 @@
   "monster_spawn_light_level": 0,
   "monster_spawn_block_light_limit": 0,
   "fixed_time": 6000,
-  "sea_level": 150
+  "sea_level": 150,
+  "noise_settings": "the_expanse:the_end"
 }

--- a/src/main/resources/the_expanse/data/minecraft/dimension_type/the_nether.json
+++ b/src/main/resources/the_expanse/data/minecraft/dimension_type/the_nether.json
@@ -17,5 +17,6 @@
   "monster_spawn_light_level": 0,
   "monster_spawn_block_light_limit": 15,
   "fixed_time": 18000,
-  "sea_level": 150
+  "sea_level": 150,
+  "noise_settings": "the_expanse:the_nether"
 }


### PR DESCRIPTION
## Summary
- add custom Overworld, Nether, and End noise settings tuned for the expanded build height
- point the dimension type overrides at the_expanse noise settings to ensure the new JSONs are used
- log the bound noise settings for each dimension when the server starts for easier runtime verification

## Testing
- ./gradlew clean build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e0918ff64c8327b4aa9df7c67c48b3