### PR TITLE
Add custom dimension noise settings

### DIFF
--- a/src/main/java/com/theexpanse/TheExpanse.java
+++ b/src/main/java/com/theexpanse/TheExpanse.java
@@ -24,6 +24,12 @@ public class TheExpanse {
         // Ensure mixin bootstrap is run
         com.theexpanse.bootstrap.MixinCompatBootstrap.init();
         System.out.println("[TheExpanse] Mod constructor called");
+        System.out.println("[TheExpanse] DimensionType registry entries:");
+        net.minecraft.core.Registry<net.minecraft.world.level.dimension.DimensionType> dimTypeRegistry =
+            net.minecraft.core.Registry.DIMENSION_TYPE;
+        dimTypeRegistry.keySet().forEach(key -> {
+            System.out.println(" - " + key.location());
+        });
 
         // Attach our runtime debug logger
         NeoForge.EVENT_BUS.addListener(this::onServerStarted);

--- a/src/main/resources/data/the_expanse/dimension_type/end.json
+++ b/src/main/resources/data/the_expanse/dimension_type/end.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": false,
+  "natural": false,
+  "piglin_safe": false,
+  "respawn_anchor_works": false,
+  "bed_works": false,
+  "has_raids": false,
+  "has_skylight": false,
+  "has_ceiling": false,
+  "coordinate_scale": 1.0,
+  "ambient_light": 0.0,
+  "min_y": -256,
+  "height": 2304,
+  "logical_height": 2304,
+  "infiniburn": "#minecraft:infiniburn_end",
+  "effects": "minecraft:the_end",
+  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 0,
+  "fixed_time": 6000,
+  "sea_level": 150,
+  "noise_settings": "the_expanse:end"
+}

--- a/src/main/resources/data/the_expanse/dimension_type/nether.json
+++ b/src/main/resources/data/the_expanse/dimension_type/nether.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": true,
+  "natural": false,
+  "piglin_safe": true,
+  "respawn_anchor_works": true,
+  "bed_works": false,
+  "has_raids": false,
+  "has_skylight": false,
+  "has_ceiling": true,
+  "coordinate_scale": 8.0,
+  "ambient_light": 0.1,
+  "min_y": -256,
+  "height": 2304,
+  "logical_height": 2304,
+  "infiniburn": "#minecraft:infiniburn_nether",
+  "effects": "minecraft:the_nether",
+  "monster_spawn_light_level": 0,
+  "monster_spawn_block_light_limit": 15,
+  "fixed_time": 18000,
+  "sea_level": 150,
+  "noise_settings": "the_expanse:nether"
+}

--- a/src/main/resources/data/the_expanse/dimension_type/overworld.json
+++ b/src/main/resources/data/the_expanse/dimension_type/overworld.json
@@ -1,0 +1,22 @@
+{
+  "ultrawarm": false,
+  "natural": true,
+  "piglin_safe": false,
+  "respawn_anchor_works": false,
+  "bed_works": true,
+  "has_raids": true,
+  "has_skylight": true,
+  "has_ceiling": false,
+  "coordinate_scale": 1.0,
+  "ambient_light": 0.0,
+  "min_y": -256,
+  "height": 2304,
+  "logical_height": 2304,
+  "infiniburn": "#minecraft:infiniburn_overworld",
+  "effects": "minecraft:overworld",
+  "monster_spawn_light_level": { "type": "minecraft:uniform", "value": 7 },
+  "monster_spawn_block_light_limit": 0,
+  "fixed_time": null,
+  "sea_level": 150,
+  "noise_settings": "the_expanse:overworld"
+}

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/end.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/end.json
@@ -1,0 +1,18 @@
+{
+  "sea_level": 0,
+  "disable_mob_generation": false,
+  "noise": { "min_y": -256, "height": 2048, "size_horizontal": 2, "size_vertical": 1 },
+  "noise_router": {
+    "barrier": { "type": "minecraft:constant", "value": -1.0 },
+    "lava": { "type": "minecraft:constant", "value": 0.0 },
+    "temperature": { "type": "minecraft:constant", "value": 0.0 },
+    "vegetation": { "type": "minecraft:constant", "value": 0.0 },
+    "continents": { "type": "minecraft:noise", "noise": "minecraft:end/base_2d" },
+    "erosion": { "type": "minecraft:constant", "value": 0.0 },
+    "depth": { "type": "minecraft:y_clamped_gradient", "from_y": -256, "to_y": 1800, "from_value": 1.0, "to_value": -1.0 },
+    "ridges": { "type": "minecraft:constant", "value": 0.0 },
+    "final_density": { "type": "minecraft:noise", "noise": "minecraft:end/base_2d" }
+  },
+  "spawn_target": [ { "target": { "block": "minecraft:end_stone" }, "state": { "Name": "minecraft:end_stone" } } ],
+  "surface_rule": { "type": "minecraft:constant", "value": 0.0 }
+}

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/nether.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/nether.json
@@ -1,0 +1,18 @@
+{
+  "sea_level": 150,
+  "disable_mob_generation": false,
+  "noise": { "min_y": -256, "height": 2256, "size_horizontal": 1, "size_vertical": 2 },
+  "noise_router": {
+    "barrier": { "type": "minecraft:constant", "value": -1.0 },
+    "lava": { "type": "minecraft:constant", "value": 0.0 },
+    "temperature": { "type": "minecraft:noise", "noise": "minecraft:nether/temperature" },
+    "vegetation": { "type": "minecraft:constant", "value": 0.0 },
+    "continents": { "type": "minecraft:noise", "noise": "minecraft:nether/base_3d" },
+    "erosion": { "type": "minecraft:noise", "noise": "minecraft:nether/base_2d" },
+    "depth": { "type": "minecraft:y_clamped_gradient", "from_y": -256, "to_y": 2000, "from_value": 1.0, "to_value": -1.0 },
+    "ridges": { "type": "minecraft:noise", "noise": "minecraft:nether/base_2d" },
+    "final_density": { "type": "minecraft:noise", "noise": "minecraft:nether/base_3d" }
+  },
+  "spawn_target": [ { "target": { "block": "minecraft:netherrack" }, "state": { "Name": "minecraft:netherrack" } } ],
+  "surface_rule": { "type": "minecraft:constant", "value": 0.0 }
+}

--- a/src/main/resources/data/the_expanse/worldgen/noise_settings/overworld.json
+++ b/src/main/resources/data/the_expanse/worldgen/noise_settings/overworld.json
@@ -1,0 +1,24 @@
+{
+  "sea_level": 150,
+  "disable_mob_generation": false,
+  "noise": { "min_y": -256, "height": 2256, "size_horizontal": 1, "size_vertical": 2 },
+  "noise_router": {
+    "barrier": { "type": "minecraft:constant", "value": -1.0 },
+    "fluid_level_floodedness": { "type": "minecraft:constant", "value": 0.0 },
+    "fluid_level_spread": { "type": "minecraft:constant", "value": 0.0 },
+    "lava": { "type": "minecraft:constant", "value": 0.0 },
+    "temperature": { "type": "minecraft:cache_2d", "argument": { "type": "minecraft:noise", "noise": "minecraft:temperature" } },
+    "vegetation": { "type": "minecraft:cache_2d", "argument": { "type": "minecraft:noise", "noise": "minecraft:vegetation" } },
+    "continents": { "type": "minecraft:noise", "noise": "minecraft:continents" },
+    "erosion": { "type": "minecraft:noise", "noise": "minecraft:erosion" },
+    "depth": { "type": "minecraft:y_clamped_gradient", "from_y": -256, "to_y": 2000, "from_value": 1.0, "to_value": -1.0 },
+    "ridges": { "type": "minecraft:noise", "noise": "minecraft:ridges" },
+    "initial_density_without_jaggedness": { "type": "minecraft:interpolated", "argument": { "type": "minecraft:noise", "noise": "minecraft:initial_density" } },
+    "final_density": { "type": "minecraft:interpolated", "argument": { "type": "minecraft:noise", "noise": "minecraft:final_density" } },
+    "vein_toggle": { "type": "minecraft:noise", "noise": "minecraft:vein_toggle" },
+    "vein_ridged": { "type": "minecraft:noise", "noise": "minecraft:vein_ridged" },
+    "vein_gap": { "type": "minecraft:noise", "noise": "minecraft:vein_gap" }
+  },
+  "spawn_target": [ { "target": { "block": "minecraft:stone" }, "state": { "Name": "minecraft:stone" } } ],
+  "surface_rule": { "type": "minecraft:stone_depth", "offset": 0, "surface_type": "floor" }
+}


### PR DESCRIPTION
## Summary
- add custom noise setting overrides for overworld, nether, and end dimensions
- provide dimension type variants pointing to the new noise settings
- log dimension type registry keys during the mod constructor for debugging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e09b13cc008327bcc4a3909deebe32