### PR TITLE
Configure Stonecutter multi-version NeoForge builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Expanse Heights
+
+## Multi-Version Builds with Stonecutter
+
+Switch to a specific Minecraft/NeoForge variant and build:
+
+```powershell
+.\gradlew.bat stonecutter use 1.20.1-neoforge
+.\gradlew.bat build
+```
+
+Run the audit client for a given variant:
+
+```powershell
+.\gradlew.bat stonecutter use 1.21.1-neoforge
+.\gradlew.bat runAuditClient
+```
+
+Audit reports are archived to `reports/parity/` as configured.

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,39 @@
-﻿plugins {
+plugins {
     id "java"
     id "net.neoforged.gradle.userdev" version "7.0.+"
 }
+
 group = "com.cyberday1"
 version = "0.1.0"
 
-java { toolchain { languageVersion = JavaLanguageVersion.of(21) } }
-neoForge { version = "21.1.209" }
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
 
-repositories { mavenCentral() }
-dependencies { }
-tasks.withType(JavaCompile).configureEach { options.release = 21 }
+neoForge {
+    version = neoForgeVersion
+
+    runs {
+        auditClient {
+            parent runs.client
+            workingDirectory project.file("run")
+
+            systemProperty "origins.debugAudit", "true"
+            arguments = ["--username", "AuditUser"]
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "net.neoforged:neoforge:${neoForgeVersion}"
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+minecraftVersion=${minecraft}
+neoForgeVersion=${neoforge}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
-﻿rootProject.name = "expanse_heights"
+plugins {
+    id "dev.kikugie.stonecutter" version "0.6.2"
+}
+
+rootProject.name = "expanse_heights"

--- a/stonecutter.json
+++ b/stonecutter.json
@@ -1,0 +1,21 @@
+{
+  "default": "1.21.1-neoforge",
+  "variants": {
+    "1.20.1-neoforge": {
+      "minecraft": "1.20.1",
+      "neoforge": "20.2.latest"
+    },
+    "1.21.1-neoforge": {
+      "minecraft": "1.21.1",
+      "neoforge": "21.1.latest"
+    },
+    "1.21.4-neoforge": {
+      "minecraft": "1.21.4",
+      "neoforge": "21.4.latest"
+    },
+    "1.21.9-neoforge": {
+      "minecraft": "1.21.9",
+      "neoforge": "21.9.latest"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable the Stonecutter plugin and define version variants for Minecraft 1.20.1 through 1.21.9
- parameterize Minecraft and NeoForge versions for each variant and wire them into the build configuration
- add an auditClient run configuration and document how to switch variants and run the audit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e28c1284832786a148fc7f025491