### PR TITLE
Update datapack and NeoForge metadata for 1.21.1

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,9 +1,0 @@
-﻿modLoader="javafml"
-loaderVersion="[4,)"
-license="MIT"
-
-[[mods]]
-modId="expanse_heights"
-version="${file.jarVersion}"
-displayName="Expanse Heights"
-description="Raises world height; terrain style stays with Tectonic."

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,22 @@
+modLoader="javafml"
+loaderVersion="[1,)"
+
+[[mods]]
+  modId="expanse_heights"
+  version="${file.jarVersion}"
+  displayName="Expanse Heights"
+  description="Extends the Overworld height while delegating terrain shape to Tectonic."
+  authors="CyberDay1"
+  displayURL="https://github.com/CyberDay1"
+  logoFile=""
+  credits=""
+
+[[dependencies.expanse_heights]]
+  modId="neoforge"
+  type="required"
+  versionRange="[21.1,)"
+
+[[dependencies.expanse_heights]]
+  modId="minecraft"
+  type="required"
+  versionRange="[1.21.1,1.22)"

--- a/src/main/resources/pack.mcmeta
+++ b/src/main/resources/pack.mcmeta
@@ -1,1 +1,6 @@
-{ "pack": { "description": "Expanse Heights built-in data", "pack_format": 34, "forge:data_pack_format": 34 } }
+{
+  "pack": {
+    "pack_format": 48,
+    "description": "Expanse Heights built-in datapack"
+  }
+}


### PR DESCRIPTION
## Summary
- raise the built-in datapack metadata to pack format 48 for Minecraft 1.21.1
- replace the legacy mods.toml with the NeoForge-compatible neoforge.mods.toml manifest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3e9a6478483279f17fbf586e86c7f