### PR TITLE
Fix Stonecutter version registrations in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -13,8 +13,22 @@ plugins {
 rootProject.name = "expanse_heights"
 
 stonecutter {
-    versions "1.20.1-forge", "1.20.2-forge", "1.20.3-forge", "1.20.4-forge", "1.20.5-forge", "1.20.6-forge",
-             "1.21.1-neoforge", "1.21.2-neoforge", "1.21.3-neoforge", "1.21.4-neoforge", "1.21.5-neoforge",
-             "1.21.6-neoforge", "1.21.7-neoforge", "1.21.8-neoforge", "1.21.9-neoforge"
-    default "1.21.1-neoforge"
+    register("1.20.1-forge")
+    register("1.20.2-forge")
+    register("1.20.3-forge")
+    register("1.20.4-forge")
+    register("1.20.5-forge")
+    register("1.20.6-forge")
+
+    register("1.21.1-neoforge")
+    register("1.21.2-neoforge")
+    register("1.21.3-neoforge")
+    register("1.21.4-neoforge")
+    register("1.21.5-neoforge")
+    register("1.21.6-neoforge")
+    register("1.21.7-neoforge")
+    register("1.21.8-neoforge")
+    register("1.21.9-neoforge")
+
+    defaultVersion("1.21.1-neoforge")
 }


### PR DESCRIPTION
## Summary
- switch Stonecutter version declarations to explicit register calls matching stonecutter.json
- set the default Stonecutter version via defaultVersion for compatibility with 0.6.2

## Testing
- `./gradlew projects` *(fails: ./gradlew not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f894a0948327bbb24a1a51c67532