### PR TITLE
Fix Stonecutter subproject registration

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,4 @@ plugins {
 
 rootProject.name = "expanse_heights"
 
-// Force Stonecutter to read stonecutter.json and register subprojects
-stonecutter {
-    loadSubprojects()
-}
+stonecutter { }

--- a/versions/1.20.1-forge/gradle.properties
+++ b/versions/1.20.1-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=26
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.20.2-forge/gradle.properties
+++ b/versions/1.20.2-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.20.3-forge/gradle.properties
+++ b/versions/1.20.3-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.20.4-forge/gradle.properties
+++ b/versions/1.20.4-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.20.5-forge/gradle.properties
+++ b/versions/1.20.5-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=34
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.20.6-forge/gradle.properties
+++ b/versions/1.20.6-forge/gradle.properties
@@ -3,4 +3,4 @@ loader=forge
 PACK_FORMAT=34
 LOADER_FILE=mods.toml
 
-BUILD_FILE=build.gradle.forge
+BUILD_SCRIPT=build.gradle.forge

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.2-neoforge/gradle.properties
+++ b/versions/1.21.2-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.3-neoforge/gradle.properties
+++ b/versions/1.21.3-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.4-neoforge/gradle.properties
+++ b/versions/1.21.4-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.5-neoforge/gradle.properties
+++ b/versions/1.21.5-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.6-neoforge/gradle.properties
+++ b/versions/1.21.6-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.7-neoforge/gradle.properties
+++ b/versions/1.21.7-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.8-neoforge/gradle.properties
+++ b/versions/1.21.8-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -3,4 +3,4 @@ loader=neoforge
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 
-BUILD_FILE=build.gradle.neoforge
+BUILD_SCRIPT=build.gradle.neoforge


### PR DESCRIPTION
## Summary
- update the Stonecutter configuration in `settings.gradle.kts` to rely on the default plugin behaviour
- rename the `BUILD_FILE` property to `BUILD_SCRIPT` across all versioned `gradle.properties` files so Stonecutter registers the subprojects

## Testing
- `./gradlew projects --console=plain` *(fails: gradle/wrapper/gradle-wrapper.jar is missing in the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e42b26a2248327a6e3ba2941fc5527