### PR TITLE
Add per-version gradle.properties for Stonecutter

### DIFF
--- a/versions/1.20.1-forge/gradle.properties
+++ b/versions/1.20.1-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.1
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=26
 LOADER_FILE=mods.toml
 

--- a/versions/1.20.2-forge/gradle.properties
+++ b/versions/1.20.2-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.2
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 

--- a/versions/1.20.3-forge/gradle.properties
+++ b/versions/1.20.3-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.3
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 

--- a/versions/1.20.4-forge/gradle.properties
+++ b/versions/1.20.4-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.4
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=32
 LOADER_FILE=mods.toml
 

--- a/versions/1.20.5-forge/gradle.properties
+++ b/versions/1.20.5-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.5
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=34
 LOADER_FILE=mods.toml
 

--- a/versions/1.20.6-forge/gradle.properties
+++ b/versions/1.20.6-forge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.20.6
 loader=forge
+loaderVersion=47.3.0
 PACK_FORMAT=34
 LOADER_FILE=mods.toml
 

--- a/versions/1.21.1-neoforge/gradle.properties
+++ b/versions/1.21.1-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.1
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.2-neoforge/gradle.properties
+++ b/versions/1.21.2-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.2
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.3-neoforge/gradle.properties
+++ b/versions/1.21.3-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.3
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.4-neoforge/gradle.properties
+++ b/versions/1.21.4-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.4
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.5-neoforge/gradle.properties
+++ b/versions/1.21.5-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.5
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.6-neoforge/gradle.properties
+++ b/versions/1.21.6-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.6
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.7-neoforge/gradle.properties
+++ b/versions/1.21.7-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.7
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.8-neoforge/gradle.properties
+++ b/versions/1.21.8-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.8
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -1,5 +1,6 @@
 mcVersion=1.21.9
 loader=neoforge
+loaderVersion=21.1.209
 PACK_FORMAT=48
 LOADER_FILE=neoforge.mods.toml
 


### PR DESCRIPTION
## Summary
- add loader metadata to the Forge 1.20.x Stonecutter gradle.properties files
- configure the NeoForge 1.21.x Stonecutter gradle.properties files to match stonecutter.json

## Testing
- ./gradlew projects --console=plain *(fails: Unable to access jarfile /workspace/the_expanse/gradle/wrapper/gradle-wrapper.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68e43140b8d88327b1854a53980c43f8