### PR TITLE
Update NeoForge build to produce mod jars

### DIFF
--- a/build.gradle.neoforge
+++ b/build.gradle.neoforge
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'base' // provides clean
+    id 'base'
     id 'net.neoforged.gradle.userdev' version '7.0.190'
 }
 
@@ -19,13 +19,13 @@ dependencies {
     implementation "net.neoforged:neoforge:${project.loaderVersion}"
 }
 
-// Ensure resources are bundled into jar
-tasks.named('jar') {
-    from sourceSets.main.output
-    archiveBaseName.set("the_expanse-${project.mcVersion}-${project.loader}")
+// Ensure a distributable mod JAR is produced
+tasks.named("jar") {
+    archiveBaseName.set("the_expanse-${project.name}")
+    from("src/main/resources")
 }
 
-// Register the jar as the default artifact
-artifacts {
-    archives tasks.jar
+// Add convenience alias
+tasks.register("buildMod") {
+    dependsOn("build", "reobfJar")
 }


### PR DESCRIPTION
## Summary
- align the NeoForge build script with the new template that sets the jar base name and bundles resources
- add a buildMod task alias for the build and reobfJar tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4651169cc8327ad101f0657df1e15