### PR TITLE
Add Stonecutter chiseled build task

### DIFF
--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("dev.kikugie.stonecutter")
+}
+stonecutter active "1.20.1-forge"
+
+stonecutter registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {
+    group = "project"
+    ofTask("build")
+}


### PR DESCRIPTION
## Summary
- add a Stonecutter Gradle script configuring the plugin
- register a reusable `chiseledBuild` task that wraps `build`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e52dc025d883278f5cb683e6ce55ef