### PR TITLE
Standardize Stonecutter build orchestration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - variant: ":1.21.1-neoforge"
+            stonecutter: "1.21.1-neoforge"
+          - variant: ":1.21.4-neoforge"
+            stonecutter: "1.21.4-neoforge"
+    name: Build ${{ matrix.variant }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Configure Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-disabled: true
+
+      - name: Run chiseled build
+        run: ./gradlew chiseledBuild -Pstonecutter.active=${{ matrix.stonecutter }}

--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@
 Switch to a specific Minecraft/NeoForge variant and build:
 
 ```powershell
-.\gradlew.bat stonecutter use 1.20.1-neoforge
-.\gradlew.bat build
+./gradlew.bat stonecutter use 1.21.1-neoforge
+./gradlew.bat chiseledBuild
 ```
 
 Run the audit client for a given variant:
 
 ```powershell
-.\gradlew.bat stonecutter use 1.21.1-neoforge
-.\gradlew.bat runAuditClient
+./gradlew.bat stonecutter use 1.21.4-neoforge
+./gradlew.bat runAuditClient
 ```
 
 Audit reports are archived to `reports/parity/` as configured.

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,9 +1,20 @@
 plugins {
-    id("dev.kikugie.stonecutter")
+    id("dev.kayla.stonecutter")
 }
-stonecutter active "1.20.1-forge"
+
+val activeVariant = providers.fileContents(layout.projectDirectory.file("stonecutter.json"))
+    .asText
+    .map { text ->
+        "\"default\"\\s*:\\s*\"([^\"]+)\"".toRegex()
+            .find(text)
+            ?.groupValues
+            ?.get(1)
+            ?: error("stonecutter.json must define a default variant")
+    }
+
+stonecutter active activeVariant.get()
 
 stonecutter registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) {
-    group = "project"
+    group = "build"
     ofTask("build")
 }


### PR DESCRIPTION
## Summary
- apply the Stonecutter 0.7.10 plugin in `stonecutter.gradle.kts`, read the default variant from `stonecutter.json`, and expose a `chiseledBuild` task that delegates to `build`
- refresh the README instructions to highlight `chiseledBuild` for multi-variant builds
- add a GitHub Actions workflow that runs `chiseledBuild` for both NeoForge variants without caching Gradle binaries

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68e52fd761388327b8a2be4692731741