### PR TITLE
Update stonecutter configuration for NeoForge variants

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,9 +11,46 @@ stonecutter {
     create("1.21.1-neoforge") {
         set("MC_VERSION", "1.21.1")
         set("NEOFORGE_VERSION", "21.1.209")
+        set("PACK_FORMAT", "48")
+    }
+    create("1.21.2-neoforge") {
+        set("MC_VERSION", "1.21.2")
+        set("NEOFORGE_VERSION", "21.2.84")
+        set("PACK_FORMAT", "57")
+    }
+    create("1.21.3-neoforge") {
+        set("MC_VERSION", "1.21.3")
+        set("NEOFORGE_VERSION", "21.3.64")
+        set("PACK_FORMAT", "57")
     }
     create("1.21.4-neoforge") {
         set("MC_VERSION", "1.21.4")
         set("NEOFORGE_VERSION", "21.4.154")
+        set("PACK_FORMAT", "61")
+    }
+    create("1.21.5-neoforge") {
+        set("MC_VERSION", "1.21.5")
+        set("NEOFORGE_VERSION", "21.5.72")
+        set("PACK_FORMAT", "71")
+    }
+    create("1.21.6-neoforge") {
+        set("MC_VERSION", "1.21.6")
+        set("NEOFORGE_VERSION", "21.6.43")
+        set("PACK_FORMAT", "80")
+    }
+    create("1.21.7-neoforge") {
+        set("MC_VERSION", "1.21.7")
+        set("NEOFORGE_VERSION", "21.7.12")
+        set("PACK_FORMAT", "81")
+    }
+    create("1.21.8-neoforge") {
+        set("MC_VERSION", "1.21.8")
+        set("NEOFORGE_VERSION", "21.8.17")
+        set("PACK_FORMAT", "81")
+    }
+    create("1.21.9-neoforge") {
+        set("MC_VERSION", "1.21.9")
+        set("NEOFORGE_VERSION", "21.9.6")
+        set("PACK_FORMAT", "88")
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,70 @@
+import dev.kikugie.stonecutter.settings.StonecutterSettingsExtension
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import java.io.File
+
+private val stonecutterConfigFile: File = settings.settingsDir.resolve("stonecutter.json")
+
+@Suppress("UNCHECKED_CAST")
+private fun loadStonecutterConfig(): MutableMap<String, Any?> {
+    if (!stonecutterConfigFile.exists()) {
+        return linkedMapOf("variants" to linkedMapOf<String, Any?>())
+    }
+    val parsed = JsonSlurper().parse(stonecutterConfigFile) as? Map<String, Any?> ?: emptyMap()
+    val root = LinkedHashMap(parsed)
+    val variants = (parsed["variants"] as? Map<String, Any?>)?.let { LinkedHashMap(it) }
+        ?: linkedMapOf<String, Any?>()
+    root["variants"] = variants
+    return root
+}
+
+private fun saveStonecutterConfig(config: Map<String, Any?>) {
+    stonecutterConfigFile.parentFile.mkdirs()
+    val json = JsonOutput.prettyPrint(JsonOutput.toJson(config))
+    stonecutterConfigFile.writeText(json + "\n")
+}
+
+private fun updateStonecutterConfig(block: MutableMap<String, Any?>.() -> Unit) {
+    val config = loadStonecutterConfig()
+    config.block()
+    saveStonecutterConfig(config)
+}
+
+private class StonecutterVersionDsl {
+    val extra: MutableMap<String, Any?> = linkedMapOf()
+}
+
+private class StonecutterVersionsDsl {
+    private val versions: MutableMap<String, Map<String, Any?>> = linkedMapOf()
+
+    fun register(name: String, block: StonecutterVersionDsl.() -> Unit) {
+        val dsl = StonecutterVersionDsl().apply(block)
+        versions[name] = linkedMapOf("replace" to LinkedHashMap(dsl.extra))
+    }
+
+    fun asMap(): Map<String, Map<String, Any?>> = LinkedHashMap(versions)
+}
+
+private fun StonecutterSettingsExtension.active(version: String) {
+    updateStonecutterConfig { this["default"] = version }
+}
+
+private fun StonecutterSettingsExtension.versions(block: StonecutterVersionsDsl.() -> Unit) {
+    val variants = StonecutterVersionsDsl().apply(block).asMap()
+    updateStonecutterConfig { this["variants"] = LinkedHashMap(variants) }
+}
+
 pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://maven.neoforged.net/releases")
         maven("https://maven.kikugie.dev/releases")
+        maven("https://maven.fabricmc.net/")
+        maven("https://maven.architectury.dev/")
+        mavenCentral()
+    }
+    plugins {
+        id("dev.kikugie.stonecutter") version "0.7.10"
     }
 }
 
@@ -12,5 +74,54 @@ plugins {
 
 rootProject.name = "the_expanse"
 
-// Apply shared Stonecutter matrix
-apply(from = "stonecutter.gradle.kts")
+stonecutter {
+    active("1.21.1-neoforge")
+
+    versions {
+        register("1.21.1-neoforge") {
+            extra["MC_VERSION"] = "1.21.1"
+            extra["NEOFORGE_VERSION"] = "21.1.209"
+            extra["PACK_FORMAT"] = "48"
+        }
+        register("1.21.2-neoforge") {
+            extra["MC_VERSION"] = "1.21.2"
+            extra["NEOFORGE_VERSION"] = "21.2.84"
+            extra["PACK_FORMAT"] = "57"
+        }
+        register("1.21.3-neoforge") {
+            extra["MC_VERSION"] = "1.21.3"
+            extra["NEOFORGE_VERSION"] = "21.3.64"
+            extra["PACK_FORMAT"] = "57"
+        }
+        register("1.21.4-neoforge") {
+            extra["MC_VERSION"] = "1.21.4"
+            extra["NEOFORGE_VERSION"] = "21.4.154"
+            extra["PACK_FORMAT"] = "61"
+        }
+        register("1.21.5-neoforge") {
+            extra["MC_VERSION"] = "1.21.5"
+            extra["NEOFORGE_VERSION"] = "21.5.72"
+            extra["PACK_FORMAT"] = "71"
+        }
+        register("1.21.6-neoforge") {
+            extra["MC_VERSION"] = "1.21.6"
+            extra["NEOFORGE_VERSION"] = "21.6.43"
+            extra["PACK_FORMAT"] = "80"
+        }
+        register("1.21.7-neoforge") {
+            extra["MC_VERSION"] = "1.21.7"
+            extra["NEOFORGE_VERSION"] = "21.7.12"
+            extra["PACK_FORMAT"] = "81"
+        }
+        register("1.21.8-neoforge") {
+            extra["MC_VERSION"] = "1.21.8"
+            extra["NEOFORGE_VERSION"] = "21.8.17"
+            extra["PACK_FORMAT"] = "81"
+        }
+        register("1.21.9-neoforge") {
+            extra["MC_VERSION"] = "1.21.9"
+            extra["NEOFORGE_VERSION"] = "21.9.6"
+            extra["PACK_FORMAT"] = "88"
+        }
+    }
+}

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,51 +1,6 @@
-stonecutter {
-    active("1.21.1-neoforge")
+import dev.kikugie.stonecutter.settings.Versions
 
-    versions {
-        register("1.21.1-neoforge") {
-            extra("MC_VERSION", "1.21.1")
-            extra("NEOFORGE_VERSION", "21.1.62")
-            extra("PACK_FORMAT", "48")
-        }
-        register("1.21.2-neoforge") {
-            extra("MC_VERSION", "1.21.2")
-            extra("NEOFORGE_VERSION", "21.2.86")
-            extra("PACK_FORMAT", "57")
-        }
-        register("1.21.3-neoforge") {
-            extra("MC_VERSION", "1.21.3")
-            extra("NEOFORGE_VERSION", "21.3.112")
-            extra("PACK_FORMAT", "57")
-        }
-        register("1.21.4-neoforge") {
-            extra("MC_VERSION", "1.21.4")
-            extra("NEOFORGE_VERSION", "21.4.154")
-            extra("PACK_FORMAT", "61")
-        }
-        register("1.21.5-neoforge") {
-            extra("MC_VERSION", "1.21.5")
-            extra("NEOFORGE_VERSION", "21.5.44")
-            extra("PACK_FORMAT", "71")
-        }
-        register("1.21.6-neoforge") {
-            extra("MC_VERSION", "1.21.6")
-            extra("NEOFORGE_VERSION", "21.6.23")
-            extra("PACK_FORMAT", "80")
-        }
-        register("1.21.7-neoforge") {
-            extra("MC_VERSION", "1.21.7")
-            extra("NEOFORGE_VERSION", "21.7.15")
-            extra("PACK_FORMAT", "81")
-        }
-        register("1.21.8-neoforge") {
-            extra("MC_VERSION", "1.21.8")
-            extra("NEOFORGE_VERSION", "21.8.8")
-            extra("PACK_FORMAT", "81")
-        }
-        register("1.21.9-neoforge") {
-            extra("MC_VERSION", "1.21.9")
-            extra("NEOFORGE_VERSION", "21.9.4")
-            extra("PACK_FORMAT", "88")
-        }
-    }
+versions {
+    // This allows you to centralize matrix logic later
+    // Currently handled inline in settings.gradle.kts
 }

--- a/stonecutter.json
+++ b/stonecutter.json
@@ -1,18 +1,68 @@
 {
-  "default": "1.21.1-neoforge",
-  "variants": {
-    "1.21.1-neoforge": {
-      "replace": {
-        "MC_VERSION": "1.21.1",
-        "NEOFORGE_VERSION": "21.1.209"
-      }
-    },
-    "1.21.4-neoforge": {
-      "replace": {
-        "MC_VERSION": "1.21.4",
-        "NEOFORGE_VERSION": "21.4.154"
-      }
+    "default": "1.21.1-neoforge",
+    "variants": {
+        "1.21.1-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.1",
+                "NEOFORGE_VERSION": "21.1.209",
+                "PACK_FORMAT": "48"
+            }
+        },
+        "1.21.2-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.2",
+                "NEOFORGE_VERSION": "21.2.84",
+                "PACK_FORMAT": "57"
+            }
+        },
+        "1.21.3-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.3",
+                "NEOFORGE_VERSION": "21.3.64",
+                "PACK_FORMAT": "57"
+            }
+        },
+        "1.21.4-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.4",
+                "NEOFORGE_VERSION": "21.4.154",
+                "PACK_FORMAT": "61"
+            }
+        },
+        "1.21.5-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.5",
+                "NEOFORGE_VERSION": "21.5.72",
+                "PACK_FORMAT": "71"
+            }
+        },
+        "1.21.6-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.6",
+                "NEOFORGE_VERSION": "21.6.43",
+                "PACK_FORMAT": "80"
+            }
+        },
+        "1.21.7-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.7",
+                "NEOFORGE_VERSION": "21.7.12",
+                "PACK_FORMAT": "81"
+            }
+        },
+        "1.21.8-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.8",
+                "NEOFORGE_VERSION": "21.8.17",
+                "PACK_FORMAT": "81"
+            }
+        },
+        "1.21.9-neoforge": {
+            "replace": {
+                "MC_VERSION": "1.21.9",
+                "NEOFORGE_VERSION": "21.9.6",
+                "PACK_FORMAT": "88"
+            }
+        }
     }
-  }
 }
-


### PR DESCRIPTION
## Summary
- add helper DSL glue so `stonecutter { active(...) / versions { ... } }` compiles in settings.gradle.kts
- register every NeoForge 1.21.1 through 1.21.9 variant with pack formats in settings, build script, and stonecutter.json

## Testing
- `./gradlew help --no-daemon --console=plain --stacktrace` *(fails: dev.kikugie.stonecutter plugin NullPointerException when applied to the root project)*

------
https://chatgpt.com/codex/tasks/task_e_68e557a6e36083278920657a0196eef9