### PR TITLE
Split NeoForge build script from template

### DIFF
--- a/build.neoforge.gradle.kts
+++ b/build.neoforge.gradle.kts
@@ -1,0 +1,45 @@
+plugins {
+    id("net.neoforged.gradle.userdev") version "7.0.190"
+    id("maven-publish")
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.neoforged.net/releases")
+}
+
+dependencies {
+    implementation("net.neoforged:neoforge:${property("NEOFORGE_VERSION")}")
+}
+
+// Expand tokens in resources (mods.toml, pack.mcmeta, etc.)
+tasks.processResources {
+    inputs.property("version", project.version)
+    inputs.property("mcVersion", property("MC_VERSION"))
+    inputs.property("neoVersion", property("NEOFORGE_VERSION"))
+
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand(
+            "version" to project.version,
+            "mcVersion" to property("MC_VERSION"),
+            "neoVersion" to property("NEOFORGE_VERSION")
+        )
+    }
+
+    filesMatching("pack.mcmeta") {
+        expand(
+            "version" to project.version,
+            "mcVersion" to property("MC_VERSION"),
+            "neoVersion" to property("NEOFORGE_VERSION"),
+            "packFormat" to property("PACK_FORMAT")
+        )
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            artifact(tasks["jar"])
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ import groovy.json.JsonSlurper
 import java.io.File
 
 private val stonecutterConfigFile: File = settings.settingsDir.resolve("stonecutter.json")
+private val NEOFORGE_BUILD_SCRIPT = "build.neoforge.gradle.kts"
 
 @Suppress("UNCHECKED_CAST")
 private fun loadStonecutterConfig(): MutableMap<String, Any?> {
@@ -32,6 +33,7 @@ private fun updateStonecutterConfig(block: MutableMap<String, Any?>.() -> Unit) 
 
 private class StonecutterVersionDsl {
     val extra: MutableMap<String, Any?> = linkedMapOf()
+    var buildscript: String? = null
 }
 
 private class StonecutterVersionsDsl {
@@ -39,7 +41,10 @@ private class StonecutterVersionsDsl {
 
     fun register(name: String, block: StonecutterVersionDsl.() -> Unit) {
         val dsl = StonecutterVersionDsl().apply(block)
-        versions[name] = linkedMapOf("replace" to LinkedHashMap(dsl.extra))
+        val entry = LinkedHashMap<String, Any?>()
+        entry["replace"] = LinkedHashMap(dsl.extra)
+        dsl.buildscript?.let { entry["buildscript"] = it }
+        versions[name] = entry
     }
 
     fun asMap(): Map<String, Map<String, Any?>> = LinkedHashMap(versions)
@@ -75,50 +80,62 @@ plugins {
 rootProject.name = "the_expanse"
 
 stonecutter {
+    shared {
+        centralScript.set("stonecutter.gradle.kts")
+    }
     active("1.21.1-neoforge")
 
     versions {
         register("1.21.1-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.1"
             extra["NEOFORGE_VERSION"] = "21.1.209"
             extra["PACK_FORMAT"] = "48"
         }
         register("1.21.2-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.2"
             extra["NEOFORGE_VERSION"] = "21.2.84"
             extra["PACK_FORMAT"] = "57"
         }
         register("1.21.3-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.3"
             extra["NEOFORGE_VERSION"] = "21.3.64"
             extra["PACK_FORMAT"] = "57"
         }
         register("1.21.4-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.4"
             extra["NEOFORGE_VERSION"] = "21.4.154"
             extra["PACK_FORMAT"] = "61"
         }
         register("1.21.5-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.5"
             extra["NEOFORGE_VERSION"] = "21.5.72"
             extra["PACK_FORMAT"] = "71"
         }
         register("1.21.6-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.6"
             extra["NEOFORGE_VERSION"] = "21.6.43"
             extra["PACK_FORMAT"] = "80"
         }
         register("1.21.7-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.7"
             extra["NEOFORGE_VERSION"] = "21.7.12"
             extra["PACK_FORMAT"] = "81"
         }
         register("1.21.8-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.8"
             extra["NEOFORGE_VERSION"] = "21.8.17"
             extra["PACK_FORMAT"] = "81"
         }
         register("1.21.9-neoforge") {
+            buildscript = NEOFORGE_BUILD_SCRIPT
             extra["MC_VERSION"] = "1.21.9"
             extra["NEOFORGE_VERSION"] = "21.9.6"
             extra["PACK_FORMAT"] = "88"

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,6 +1,6 @@
-import dev.kikugie.stonecutter.settings.Versions
-
-versions {
-    // This allows you to centralize matrix logic later
-    // Currently handled inline in settings.gradle.kts
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+    withSourcesJar()
 }

--- a/stonecutter.json
+++ b/stonecutter.json
@@ -6,63 +6,72 @@
                 "MC_VERSION": "1.21.1",
                 "NEOFORGE_VERSION": "21.1.209",
                 "PACK_FORMAT": "48"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.2-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.2",
                 "NEOFORGE_VERSION": "21.2.84",
                 "PACK_FORMAT": "57"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.3-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.3",
                 "NEOFORGE_VERSION": "21.3.64",
                 "PACK_FORMAT": "57"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.4-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.4",
                 "NEOFORGE_VERSION": "21.4.154",
                 "PACK_FORMAT": "61"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.5-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.5",
                 "NEOFORGE_VERSION": "21.5.72",
                 "PACK_FORMAT": "71"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.6-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.6",
                 "NEOFORGE_VERSION": "21.6.43",
                 "PACK_FORMAT": "80"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.7-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.7",
                 "NEOFORGE_VERSION": "21.7.12",
                 "PACK_FORMAT": "81"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.8-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.8",
                 "NEOFORGE_VERSION": "21.8.17",
                 "PACK_FORMAT": "81"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.9-neoforge": {
             "replace": {
                 "MC_VERSION": "1.21.9",
                 "NEOFORGE_VERSION": "21.9.6",
                 "PACK_FORMAT": "88"
-            }
+            },
+            "buildscript": "build.neoforge.gradle.kts"
         }
     }
 }

--- a/template/build.gradle.kts
+++ b/template/build.gradle.kts
@@ -1,14 +1,5 @@
 plugins {
     id("java")
-    id("net.neoforged.gradle.userdev") version "7.0.190"
-    id("maven-publish")
-}
-
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
-    }
-    withSourcesJar()
 }
 
 group = "com.theexpanse"
@@ -19,41 +10,4 @@ base {
 
 repositories {
     mavenCentral()
-    maven("https://maven.neoforged.net/releases")
-}
-
-dependencies {
-    implementation("net.neoforged:neoforge:${property("NEOFORGE_VERSION")}")
-}
-
-// Expand tokens in resources (mods.toml, pack.mcmeta, etc.)
-tasks.processResources {
-    inputs.property("version", project.version)
-    inputs.property("mcVersion", property("MC_VERSION"))
-    inputs.property("neoVersion", property("NEOFORGE_VERSION"))
-
-    filesMatching("META-INF/neoforge.mods.toml") {
-        expand(
-            "version" to project.version,
-            "mcVersion" to property("MC_VERSION"),
-            "neoVersion" to property("NEOFORGE_VERSION")
-        )
-    }
-
-    filesMatching("pack.mcmeta") {
-        expand(
-            "version" to project.version,
-            "mcVersion" to property("MC_VERSION"),
-            "neoVersion" to property("NEOFORGE_VERSION"),
-            "packFormat" to property("PACK_FORMAT")
-        )
-    }
-}
-
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            artifact(tasks["jar"])
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `build.neoforge.gradle.kts` containing NeoForge plugins, repository, dependencies, resource expansion, and publishing setup
- trim the template build script down to shared Java metadata while moving the toolchain settings into `stonecutter.gradle.kts`
- extend the stonecutter settings/configuration to point NeoForge variants at the new build script and declare it as the shared central script

## Testing
- `./gradlew chiseledBuild -Pstonecutter.active=1.21.1-neoforge` *(fails: NullPointerException inside dev.kikugie.stonecutter plugin)*
- `./gradlew chiseledBuild -Pstonecutter.active=1.21.1-neoforge --stacktrace` *(fails: same NullPointerException for additional diagnostics)*

------
https://chatgpt.com/codex/tasks/task_b_68e58b7151c4832f934dd0110cf08f5b