### PR TITLE
Add JEI cross-links for Patchouli overlays

### DIFF
--- a/template/build.gradle.kts
+++ b/template/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.JavaExec
 plugins {
     id("java")
     id("net.neoforged.gradle.userdev") version "7.0.190"
@@ -56,4 +57,17 @@ publishing {
             artifact(tasks["jar"])
         }
     }
+}
+
+
+val datapackValidationTest by tasks.registering(JavaExec::class) {
+    group = "verification"
+    description = "Validates Patchouli cross-link metadata for JEI HUD overlays."
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("com.theexpanse.datapack.DatapackValidationTest")
+    workingDir = project.projectDir
+}
+
+tasks.named("check") {
+    dependsOn(datapackValidationTest)
 }

--- a/template/src/main/resources/assets/cyclic/lang/en_us.json
+++ b/template/src/main/resources/assets/cyclic/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "cyclic.overlay.patchouli.link": "View JEI HUD overlay"
+}

--- a/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/energy_bank_overlay.json
+++ b/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/energy_bank_overlay.json
@@ -1,0 +1,22 @@
+{
+  "name": "Energy Bank HUD",
+  "icon": "cyclic:energy_bank",
+  "category": "cyclic:machines/overlays",
+  "read_by_default": true,
+  "sortnum": 3,
+  "extra_recipe_categories": [
+    "jei:cyclic:hud_overlay"
+  ],
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "cyclic:energy_bank",
+      "title": "Energy Bank Overlay",
+      "text": "$(thing)$(translate:cyclic.overlay.patchouli.link)"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "See charge rate, stored FE, and IO limits directly from the overlay."
+    }
+  ]
+}

--- a/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/fluid_pump_overlay.json
+++ b/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/fluid_pump_overlay.json
@@ -1,0 +1,22 @@
+{
+  "name": "Fluid Pump HUD",
+  "icon": "cyclic:fluid_pump",
+  "category": "cyclic:machines/overlays",
+  "read_by_default": true,
+  "sortnum": 1,
+  "extra_recipe_categories": [
+    "jei:cyclic:hud_overlay"
+  ],
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "cyclic:fluid_pump",
+      "title": "Fluid Pump Overlay",
+      "text": "$(thing)$(translate:cyclic.overlay.patchouli.link)"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Use the JEI overlay to inspect fluid levels and tank throughput without opening the machine UI."
+    }
+  ]
+}

--- a/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/item_infuser_overlay.json
+++ b/template/src/main/resources/assets/cyclic/patchouli_books/guide/en_us/entries/machines/item_infuser_overlay.json
@@ -1,0 +1,22 @@
+{
+  "name": "Item Infuser HUD",
+  "icon": "cyclic:item_infuser",
+  "category": "cyclic:machines/overlays",
+  "read_by_default": true,
+  "sortnum": 2,
+  "extra_recipe_categories": [
+    "jei:cyclic:hud_overlay"
+  ],
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "cyclic:item_infuser",
+      "title": "Item Infuser Overlay",
+      "text": "$(thing)$(translate:cyclic.overlay.patchouli.link)"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Track processing time and catalyst burn at a glance from the JEI overlay."
+    }
+  ]
+}

--- a/template/src/test/java/com/theexpanse/datapack/DatapackValidationTest.java
+++ b/template/src/test/java/com/theexpanse/datapack/DatapackValidationTest.java
@@ -1,0 +1,124 @@
+package com.theexpanse.datapack;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Lightweight datapack validation to ensure JEI cross-links remain consistent.
+ */
+public final class DatapackValidationTest {
+    private static final Pattern EXTRA_RECIPE_PATTERN = Pattern.compile("\\\"extra_recipe_categories\\\"\\s*:\\s*\\[(.*?)\\]", Pattern.DOTALL);
+    private static final Pattern OVERLAY_KEY_PATTERN = Pattern.compile("\\\"jei:cyclic:hud_overlay\\\"");
+    private static final Pattern TRANSLATION_KEY_PATTERN = Pattern.compile("cyclic\\.overlay\\.patchouli\\.link");
+    private static final Pattern LANG_ENTRY_PATTERN = Pattern.compile("\\\"cyclic\\.overlay\\.patchouli\\.link\\\"\\s*:\\s*\\\"[^\\\"]+\\\"");
+
+    private DatapackValidationTest() {
+    }
+
+    public static void main(String[] args) throws IOException {
+        Path projectRoot = Paths.get("").toAbsolutePath();
+        Path resourcesRoot = resolveResourcesRoot(projectRoot);
+        Path patchouliRoot = resourcesRoot.resolve("assets/cyclic/patchouli_books");
+        requireDirectory(patchouliRoot, "Patchouli book directory");
+
+        List<Path> machineEntries;
+        try (Stream<Path> stream = Files.walk(patchouliRoot)) {
+            machineEntries = stream
+                .filter(path -> Files.isRegularFile(path) && path.toString().endsWith(".json"))
+                .filter(path -> path.toString().replace('\\', '/').contains("/entries/machines/"))
+                .sorted(Comparator.comparing(path -> patchouliRoot.relativize(path).toString()))
+                .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        if (machineEntries.isEmpty()) {
+            throw new IllegalStateException("No machine overlay entries found under " + patchouliRoot);
+        }
+
+        for (Path entry : machineEntries) {
+            validateEntry(entry);
+        }
+
+        Path langFile = resourcesRoot.resolve("assets/cyclic/lang/en_us.json");
+        requireFile(langFile, "cyclic language file");
+        String langContent = Files.readString(langFile, StandardCharsets.UTF_8);
+        Matcher langMatcher = LANG_ENTRY_PATTERN.matcher(langContent);
+        int langCount = countMatches(langMatcher);
+        if (langCount == 0) {
+            throw new IllegalStateException("Missing localization for cyclic.overlay.patchouli.link in " + langFile);
+        }
+        if (langCount > 1) {
+            throw new IllegalStateException("Duplicate localization keys for cyclic.overlay.patchouli.link in " + langFile);
+        }
+
+        System.out.println("DatapackValidationTest: " + machineEntries.size() + " machine overlay entries validated successfully.");
+    }
+
+    private static void validateEntry(Path entry) throws IOException {
+        String content = Files.readString(entry, StandardCharsets.UTF_8);
+
+        Matcher extraMatcher = EXTRA_RECIPE_PATTERN.matcher(content);
+        if (!extraMatcher.find()) {
+            throw new IllegalStateException("Missing extra_recipe_categories in " + entry);
+        }
+        String categoryBlock = extraMatcher.group(1);
+        int overlayCount = countMatches(OVERLAY_KEY_PATTERN.matcher(categoryBlock));
+        if (overlayCount == 0) {
+            throw new IllegalStateException("No JEI overlay category present in " + entry);
+        }
+        if (overlayCount > 1) {
+            throw new IllegalStateException("Duplicate JEI overlay categories found in " + entry);
+        }
+
+        Matcher translationMatcher = TRANSLATION_KEY_PATTERN.matcher(content);
+        int translationCount = countMatches(translationMatcher);
+        if (translationCount == 0) {
+            throw new IllegalStateException("Missing localized link reference in " + entry);
+        }
+        if (translationCount > 1) {
+            throw new IllegalStateException("Duplicate localized link references in " + entry);
+        }
+    }
+
+    private static int countMatches(Matcher matcher) {
+        int count = 0;
+        while (matcher.find()) {
+            count++;
+        }
+        return count;
+    }
+
+    private static void requireDirectory(Path directory, String description) {
+        if (!Files.isDirectory(directory)) {
+            throw new IllegalStateException(description + " not found: " + directory.toAbsolutePath());
+        }
+    }
+
+    private static void requireFile(Path file, String description) {
+        if (!Files.isRegularFile(file)) {
+            throw new IllegalStateException(description + " not found: " + file.toAbsolutePath());
+        }
+    }
+
+    private static Path resolveResourcesRoot(Path projectRoot) {
+        Path[] candidates = new Path[] {
+            projectRoot.resolve("src/main/resources"),
+            projectRoot.resolve("template/src/main/resources")
+        };
+        for (Path candidate : candidates) {
+            if (Files.isDirectory(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("Unable to locate resources directory under " + projectRoot);
+    }
+}


### PR DESCRIPTION
## Completed
- Added JEI HUD overlay recipe categories and localized cross-link text to the Patchouli machine overlay entries.
- Introduced `cyclic.overlay.patchouli.link` to the cyclic language file for consistent link text.
- Implemented `DatapackValidationTest` and wired it into Gradle to catch missing or duplicate overlay cross-links.

## TODOs
- Runtime verification of JEI ↔ Patchouli link rendering in a full client environment.

## Stubs
- None.

## Next steps
- Finalize optional mod overlays (Jade/TOP) and Curios integration.


------
https://chatgpt.com/codex/tasks/task_b_68e5a1297168832fb4fa5bde20cf890b