### PR TITLE
Configure Stonecutter controller and NeoForge toolchain

### DIFF
--- a/build.neoforge.gradle.kts
+++ b/build.neoforge.gradle.kts
@@ -1,9 +1,14 @@
 import org.gradle.api.Project
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 import java.util.Properties
 
 plugins {
     id("net.neoforged.gradle.userdev") version "7.0.190"
     id("maven-publish")
+}
+
+java {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 val configurableProperties = Properties().apply {
@@ -26,35 +31,39 @@ val useMixins = project.resolveToggle("useMixins", false)
 extensions.extraProperties["enableDatagen"] = enableDatagen
 extensions.extraProperties["useMixins"] = useMixins
 
+val mcVersion = project.property("MC_VERSION").toString()
+val neoForgeVersion = project.property("NEOFORGE_VERSION").toString()
+val packFormat = project.property("PACK_FORMAT").toString()
+
 repositories {
     mavenCentral()
     maven("https://maven.neoforged.net/releases")
 }
 
 dependencies {
-    implementation("net.neoforged:neoforge:${property("NEOFORGE_VERSION")}")
+    implementation("net.neoforged:neoforge:$neoForgeVersion")
 }
 
 // Expand tokens in resources (mods.toml, pack.mcmeta, etc.)
 tasks.processResources {
     inputs.property("version", project.version)
-    inputs.property("mcVersion", property("MC_VERSION"))
-    inputs.property("neoVersion", property("NEOFORGE_VERSION"))
+    inputs.property("mcVersion", mcVersion)
+    inputs.property("neoVersion", neoForgeVersion)
 
     filesMatching("META-INF/neoforge.mods.toml") {
         expand(
             "version" to project.version,
-            "mcVersion" to property("MC_VERSION"),
-            "neoVersion" to property("NEOFORGE_VERSION")
+            "mcVersion" to mcVersion,
+            "neoVersion" to neoForgeVersion
         )
     }
 
     filesMatching("pack.mcmeta") {
         expand(
             "version" to project.version,
-            "mcVersion" to property("MC_VERSION"),
-            "neoVersion" to property("NEOFORGE_VERSION"),
-            "packFormat" to property("PACK_FORMAT")
+            "mcVersion" to mcVersion,
+            "neoVersion" to neoForgeVersion,
+            "packFormat" to packFormat
         )
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,4 +18,35 @@ plugins {
 
 rootProject.name = "the_expanse"
 
-apply(from = "stonecutter.gradle.kts")
+val supportedVariants = listOf(
+    "1.21.1-neoforge",
+    "1.21.2-neoforge",
+    "1.21.3-neoforge",
+    "1.21.4-neoforge",
+    "1.21.5-neoforge",
+    "1.21.6-neoforge",
+    "1.21.7-neoforge",
+    "1.21.8-neoforge",
+    "1.21.9-neoforge",
+)
+
+val defaultVariant = "1.21.1-neoforge"
+val requestedVariant = providers.gradleProperty("stonecutter.active")
+    .orElse(defaultVariant)
+    .get()
+
+require(requestedVariant in supportedVariants) {
+    "Unknown Stonecutter variant '$requestedVariant'. Supported variants: ${supportedVariants.joinToString()}"
+}
+
+val activeVariants = linkedSetOf(defaultVariant, requestedVariant)
+
+stonecutter {
+    create(rootProject) {
+        kotlinController.set(true)
+        centralScript.set("build.neoforge.gradle.kts")
+        vcsVersion.set(defaultVariant)
+
+        versions(activeVariants)
+    }
+}

--- a/stonecutter.json
+++ b/stonecutter.json
@@ -3,73 +3,73 @@
     "variants": {
         "1.21.1-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.1",
                 "NEOFORGE_VERSION": "21.1.209",
-                "PACK_FORMAT": "48"
+                "PACK_FORMAT": "48",
+                "MC_VERSION": "1.21.1"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.2-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.2",
                 "NEOFORGE_VERSION": "21.2.84",
-                "PACK_FORMAT": "57"
+                "PACK_FORMAT": "57",
+                "MC_VERSION": "1.21.2"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.3-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.3",
                 "NEOFORGE_VERSION": "21.3.64",
-                "PACK_FORMAT": "57"
+                "PACK_FORMAT": "57",
+                "MC_VERSION": "1.21.3"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.4-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.4",
                 "NEOFORGE_VERSION": "21.4.154",
-                "PACK_FORMAT": "61"
+                "PACK_FORMAT": "61",
+                "MC_VERSION": "1.21.4"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.5-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.5",
                 "NEOFORGE_VERSION": "21.5.72",
-                "PACK_FORMAT": "71"
+                "PACK_FORMAT": "71",
+                "MC_VERSION": "1.21.5"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.6-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.6",
                 "NEOFORGE_VERSION": "21.6.43",
-                "PACK_FORMAT": "80"
+                "PACK_FORMAT": "80",
+                "MC_VERSION": "1.21.6"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.7-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.7",
                 "NEOFORGE_VERSION": "21.7.12",
-                "PACK_FORMAT": "81"
+                "PACK_FORMAT": "81",
+                "MC_VERSION": "1.21.7"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.8-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.8",
                 "NEOFORGE_VERSION": "21.8.17",
-                "PACK_FORMAT": "81"
+                "PACK_FORMAT": "81",
+                "MC_VERSION": "1.21.8"
             },
             "buildscript": "build.neoforge.gradle.kts"
         },
         "1.21.9-neoforge": {
             "replace": {
-                "MC_VERSION": "1.21.9",
                 "NEOFORGE_VERSION": "21.9.6",
-                "PACK_FORMAT": "88"
+                "PACK_FORMAT": "88",
+                "MC_VERSION": "1.21.9"
             },
             "buildscript": "build.neoforge.gradle.kts"
         }


### PR DESCRIPTION
## Summary
- migrate settings.gradle.kts and stonecutter.gradle.kts to the Stonecutter 0.7.10 controller DSL
- ensure each variant loads its gradle.properties replacements and keep the JSON in sync
- configure the NeoForge buildscript to request a Java 21 toolchain so jarJar resolves correctly

## Testing
- `./gradlew help --no-daemon --stacktrace --console=plain`
- `./gradlew chiseledBuild -Pstonecutter.active=1.21.1-neoforge --no-daemon --stacktrace --console=plain` *(fails: compile errors in src/main/java/com/theexpanse/worldgen/OreScaler.java)*

------
https://chatgpt.com/codex/tasks/task_b_68e66687a604832f855d18ea8e5461cc