### PR TITLE
Expand NeoForge CI matrix to cover 1.21.1–1.21.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - variant: ":1.21.1-neoforge"
-            stonecutter: "1.21.1-neoforge"
-          - variant: ":1.21.4-neoforge"
-            stonecutter: "1.21.4-neoforge"
-    name: Build ${{ matrix.variant }}
+        variant:
+          - 1.21.1-neoforge
+          - 1.21.2-neoforge
+          - 1.21.3-neoforge
+          - 1.21.4-neoforge
+          - 1.21.5-neoforge
+          - 1.21.6-neoforge
+          - 1.21.7-neoforge
+          - 1.21.8-neoforge
+          - 1.21.9-neoforge
+    name: Build :${{ matrix.variant }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -35,4 +40,4 @@ jobs:
           cache-disabled: true
 
       - name: Run chiseled build
-        run: ./gradlew chiseledBuild -Pstonecutter.active=${{ matrix.stonecutter }}
+        run: ./gradlew chiseledBuild -Pstonecutter.active=${{ matrix.variant }}


### PR DESCRIPTION
## Summary
- expand the GitHub Actions matrix so every NeoForge variant from 1.21.1 through 1.21.9 is built
- keep Java 21 setup and Gradle cache disabled while running `chiseledBuild` with the active variant from the matrix

## Testing
- ./gradlew --console=plain chiseledBuild -Pstonecutter.active=1.21.1-neoforge *(fails: neoFormRename reports missing merged output jar)*
- ./gradlew --console=plain chiseledBuild -Pstonecutter.active=1.21.3-neoforge --no-build-cache *(fails: `OreScaler` compilation errors on this MC version)*
- ./gradlew --console=plain chiseledBuild -Pstonecutter.active=1.21.9-neoforge *(fails: upstream `net.neoforged:neoforge:21.9.6` artifact not published)*

------
https://chatgpt.com/codex/tasks/task_b_68e66d15ce94832f9683361b6ac23cd1