### PR TITLE
Add CI workflow for Stonecutter NeoForge variants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: CI :${{ matrix.mc_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mc_version:
+          - 1.21.1-neoforge
+          - 1.21.2-neoforge
+          - 1.21.3-neoforge
+          - 1.21.4-neoforge
+          - 1.21.5-neoforge
+          - 1.21.6-neoforge
+          - 1.21.7-neoforge
+          - 1.21.8-neoforge
+          - 1.21.9-neoforge
+    env:
+      STONECUTTER_DISABLE_PUBLISH: "true"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Validate configuration
+        run: ./gradlew help -Pstonecutter.active=${{ matrix.mc_version }} --stacktrace
+
+      - name: Build with Gradle
+        run: ./gradlew chiseledBuild -Pstonecutter.active=${{ matrix.mc_version }} --stacktrace
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports-${{ matrix.mc_version }}
+          path: build/reports/tests
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that validates each Stonecutter NeoForge variant from 1.21.1 through 1.21.9
- run the Gradle help and chiseledBuild tasks with stacktraces for each matrix entry while disabling publishing
- collect test reports as artifacts whenever the workflow fails

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_b_68e688ed0214832fba9b944ac03fc98c