### PR TITLE
Move NeoForge moddev plugin to template build script

### DIFF
--- a/template/build.gradle.kts
+++ b/template/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.JavaExec
 plugins {
+    id("net.neoforged.moddev") version "1.+"
     id("java")
 }
 


### PR DESCRIPTION
## Summary
- apply the `net.neoforged.moddev` plugin from the template build script so Gradle can initialize it during project builds

## Testing
- ./gradlew help --stacktrace

## TODO
- Migrate the `net.neoforged.moddev` plugin into `build.neoforge.gradle.kts` once that build script fully replaces the template configuration


------
https://chatgpt.com/codex/tasks/task_b_68e69577ad3c832f92dd199a3f461e56